### PR TITLE
Responsive route repo dev

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,11 @@ dependencies {
     // Moshi
     implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
     implementation 'androidx.test.ext:junit-ktx:1.1.3'
+    implementation 'co.infinum:retromock:1.1.1'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     // Moshi
     implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
     implementation 'androidx.test.ext:junit-ktx:1.1.3'
-    implementation 'co.infinum:retromock:1.1.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/Route.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/Route.kt
@@ -1,6 +1,6 @@
 package com.example.routesuggesterapp.data.network
 
-open class Route(
+data class Route(
     val id: Int,
     val routeName: String,
     val mountainName: String,

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
@@ -26,6 +26,6 @@ interface RouteApiService {
 }
 
 object RouteApi {
-    val retrofitService : RouteApiService by lazy {
+    val routeApiService : RouteApiService by lazy {
         retrofit.create(RouteApiService::class.java) }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
@@ -21,11 +21,11 @@ interface RouteApiService {
     suspend fun getRoutesBySearchCriteria(body: RoutesSearchCriteria) : List<Route>
 
     @POST("search/suggest_by_weather")
-    suspend fun getRoutesBySearchCriteriaAndWeather(body: RoutesSearchCriteria) : List<Route>
+    suspend fun getRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<Route>
 
 }
 
 object RouteApi {
-    val routeApiService : RouteApiService by lazy {
+    val service : RouteApiService by lazy {
         retrofit.create(RouteApiService::class.java) }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRoute.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRoute.kt
@@ -2,42 +2,8 @@ package com.example.routesuggesterapp.data.repo
 
 import com.example.routesuggesterapp.data.network.Route
 
-class ResponsiveRoute(
+data class ResponsiveRoute(
     var favorite: Boolean,
-    id: Int,
-    routeName: String,
-    mountainName: String,
-    isStandardRoute: Boolean, 
-    isSnowRoute: Boolean,
-    grade: Int,
-    trailhead: String,
-    summitElevation: Int,
-    gain: Int,
-    length: Int,
-    exposure: String,
-    rockfallPotential: String,
-    routeFinding: String,
-    commitment: String,
-    roadDifficulty: Int,
-    routeUrl: String,
-    trailheadUrl: String
+    val route: Route
 )
-    : Route(
-    id,
-    routeName,
-    mountainName,
-    isStandardRoute,
-    isSnowRoute,
-    grade,
-    trailhead,
-    summitElevation,
-    gain,
-    length,
-    exposure,
-    rockfallPotential,
-    routeFinding,
-    commitment,
-    roadDifficulty,
-    routeUrl,
-    trailheadUrl,
-)
+

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -1,5 +1,6 @@
 package com.example.routesuggesterapp.data.repo
 
+import androidx.annotation.VisibleForTesting
 import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
 import com.example.routesuggesterapp.data.network.Route
@@ -19,7 +20,8 @@ class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: R
         return buildListOfResponsiveRoutes(routes)
     }
 
-    private suspend fun buildListOfResponsiveRoutes(routes: List<Route>) : List<ResponsiveRoute> {
+    @VisibleForTesting
+    suspend fun buildListOfResponsiveRoutes(routes: List<Route>) : List<ResponsiveRoute> {
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -7,13 +7,10 @@ import com.example.routesuggesterapp.data.network.RouteApi
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import kotlinx.coroutines.flow.single
 
-class ResponsiveRouteRepo(
-    private val dao: FavoritedRouteDao,
-    private val api: RouteApi
-    )
-{
+class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: RouteApi) {
+
     suspend fun getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
-        val routes = api.routeApiService.getRoutesBySearchCriteria(criteria)
+        val routes = api.service.getRoutesBySearchCriteria(criteria)
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {
@@ -27,7 +24,7 @@ class ResponsiveRouteRepo(
     }
 
     suspend fun getResponsiveRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
-        val routes = api.routeApiService.getRoutesBySearchCriteriaAndWeather(criteria)
+        val routes = api.service.getRoutesBySearchCriteriaAndWeather(criteria)
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {
@@ -40,10 +37,12 @@ class ResponsiveRouteRepo(
         return listOfResponsiveRoutes
     }
 
+    //verify mockito
     suspend fun favoriteRoute(route: Route) {
         dao.insert(FavoritedRoute(routeId = route.id))
     }
 
+    //verify mockito
     suspend fun unfavoriteRoute(route: Route) {
         dao.delete(FavoritedRoute(routeId = route.id))
     }

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -34,13 +34,13 @@ class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: R
         return listOfResponsiveRoutes
     }
 
-    //verify mockito
-    private suspend fun favoriteRoute(route: Route) {
+    @VisibleForTesting
+    suspend fun favoriteRoute(route: Route) {
         dao.insert(FavoritedRoute(routeId = route.id))
     }
 
-    //verify mockito
-    private suspend fun unfavoriteRoute(route: Route) {
+    @VisibleForTesting
+    suspend fun unfavoriteRoute(route: Route) {
         dao.delete(FavoritedRoute(routeId = route.id))
     }
 

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -1,7 +1,58 @@
 package com.example.routesuggesterapp.data.repo
 
+import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
+import com.example.routesuggesterapp.data.network.Route
 import com.example.routesuggesterapp.data.network.RouteApi
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
+import kotlinx.coroutines.flow.single
 
-class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: RouteApi) {
+class ResponsiveRouteRepo(
+    private val dao: FavoritedRouteDao,
+    private val api: RouteApi
+    )
+{
+    suspend fun getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
+        val routes = api.routeApiService.getRoutesBySearchCriteria(criteria)
+        val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
+
+        routes.forEach {
+            when (isRouteFavorited(it)) {
+                listOfResponsiveRoutes.add(ResponsiveRoute(true, it))
+                else -> listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
+            }
+        }
+        return listOfResponsiveRoutes
+    }
+
+    suspend fun getResponsiveRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
+        val routes = api.routeApiService.getRoutesBySearchCriteriaAndWeather(criteria)
+        val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
+
+        routes.forEach {
+            when (isRouteFavorited(it)) {
+                listOfResponsiveRoutes.add(ResponsiveRoute(true, it))
+                else -> listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
+            }
+        }
+        return listOfResponsiveRoutes
+    }
+
+    suspend fun favoriteRoute(route: Route) {
+        dao.insert(FavoritedRoute(routeId = route.id))
+    }
+
+    suspend fun unfavoriteRoute(route: Route) {
+        dao.delete(FavoritedRoute(routeId = route.id))
+    }
+
+    private suspend fun isRouteFavorited(route: Route) : Boolean {
+        return try {
+            dao.getRouteId(route.id).single()
+            true
+        } catch (e: NoSuchElementException ) {
+            false
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -17,9 +17,10 @@ class ResponsiveRouteRepo(
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {
-            when (isRouteFavorited(it)) {
+            if (isRouteFavorited(it)) {
                 listOfResponsiveRoutes.add(ResponsiveRoute(true, it))
-                else -> listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
+            } else {
+                listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
             }
         }
         return listOfResponsiveRoutes
@@ -30,9 +31,10 @@ class ResponsiveRouteRepo(
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {
-            when (isRouteFavorited(it)) {
+            if (isRouteFavorited(it)) {
                 listOfResponsiveRoutes.add(ResponsiveRoute(true, it))
-                else -> listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
+            } else {
+                listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
             }
         }
         return listOfResponsiveRoutes

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -11,20 +11,15 @@ class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: R
 
     suspend fun getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
         val routes = api.service.getRoutesBySearchCriteria(criteria)
-        val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
-
-        routes.forEach {
-            if (isRouteFavorited(it)) {
-                listOfResponsiveRoutes.add(ResponsiveRoute(true, it))
-            } else {
-                listOfResponsiveRoutes.add(ResponsiveRoute(false, it))
-            }
-        }
-        return listOfResponsiveRoutes
+        return buildListOfResponsiveRoutes(routes)
     }
 
     suspend fun getResponsiveRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
         val routes = api.service.getRoutesBySearchCriteriaAndWeather(criteria)
+        return buildListOfResponsiveRoutes(routes)
+    }
+
+    private suspend fun buildListOfResponsiveRoutes(routes: List<Route>) : List<ResponsiveRoute> {
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
 
         routes.forEach {
@@ -38,12 +33,12 @@ class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: R
     }
 
     //verify mockito
-    suspend fun favoriteRoute(route: Route) {
+    private suspend fun favoriteRoute(route: Route) {
         dao.insert(FavoritedRoute(routeId = route.id))
     }
 
     //verify mockito
-    suspend fun unfavoriteRoute(route: Route) {
+    private suspend fun unfavoriteRoute(route: Route) {
         dao.delete(FavoritedRoute(routeId = route.id))
     }
 

--- a/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
@@ -3,7 +3,9 @@ package com.example.routesuggesterapp.ui.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.routesuggesterapp.data.repo.ResponsiveRoute
+import kotlinx.coroutines.launch
 
 class ResponsiveRouteViewModel : ViewModel() {
     private val _routes = MutableLiveData<List<ResponsiveRoute>>()

--- a/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
@@ -3,9 +3,7 @@ package com.example.routesuggesterapp.ui.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.example.routesuggesterapp.data.repo.ResponsiveRoute
-import kotlinx.coroutines.launch
 
 class ResponsiveRouteViewModel : ViewModel() {
     private val _routes = MutableLiveData<List<ResponsiveRoute>>()

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -1,5 +1,6 @@
 package com.example.routesuggesterapp.data.repo
 
+import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
 import com.example.routesuggesterapp.data.network.Route
 import com.example.routesuggesterapp.data.network.RouteApi
@@ -15,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.*
 
@@ -99,6 +101,21 @@ class ResponsiveRouteRepoTest {
         )
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun itFavoritesRouteByDao() = runTest{
+        dao = mock()
+        repo = ResponsiveRouteRepo(dao, RouteApi)
+        repo.favoriteRoute(keyHoleRoute)
+        verify(dao).insert(FavoritedRoute(routeId = keyHoleRoute.id))
+    }
 
-
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun itUnFavoritesRouteByDao() = runTest {
+        dao = mock()
+        repo = ResponsiveRouteRepo(dao, RouteApi)
+        repo.unfavoriteRoute(keyHoleRoute)
+        verify(dao).delete(FavoritedRoute(routeId = keyHoleRoute.id))
+    }
 }

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -22,9 +22,7 @@ import java.util.*
 
 class ResponsiveRouteRepoTest {
     private lateinit var dao: FavoritedRouteDao
-    private lateinit var api: RouteApiService
     private lateinit var repo: ResponsiveRouteRepo
-    private lateinit var longsPeakCriteria: RoutesSearchCriteria
     private lateinit var keyHoleRoute: Route
     private lateinit var loftRoute: Route
     private lateinit var keyHoleRouteFavorited: ResponsiveRoute

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -30,23 +30,6 @@ class ResponsiveRouteRepoTest {
 
     @Before
     fun initData() {
-        longsPeakCriteria = RoutesSearchCriteria(
-            Optional.empty(),
-            Optional.of("Longs Peak"),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty()
-        )
-
         keyHoleRoute = Route(
             1,
             "Keyhole Route",
@@ -91,11 +74,18 @@ class ResponsiveRouteRepoTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun itGetsResponsiveRoutesBySearchCriteria() = runTest {
-        api = mock()
-        whenever(service.getRoutesBySearchCriteria(longsPeakCriteria)) doReturn listOf()
-        whenever(service.getRoutesBySearchCriteriaAndWeather(longsPeakCriteria)) doReturn listOf()
+    fun itBuildsAnEmptyListOfResponsiveRoutes() = runTest {
+        dao = mock()
+        repo = ResponsiveRouteRepo(dao, RouteApi)
+        assertEquals(
+            repo.buildListOfResponsiveRoutes(listOf()),
+            listOf<ResponsiveRoute>()
+        )
+    }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun itBuildsAListOfResponsiveRoutes() = runTest {
         dao = mock()
         whenever(dao.getRouteId(keyHoleRoute.id)) doReturn flow {
             emit(keyHoleRoute.id)
@@ -104,13 +94,11 @@ class ResponsiveRouteRepoTest {
 
         repo = ResponsiveRouteRepo(dao, RouteApi)
         assertEquals(
-            repo.getResponsiveRoutesBySearchCriteria(longsPeakCriteria),
+            repo.buildListOfResponsiveRoutes(listOf(keyHoleRoute, loftRoute)),
             listOf(keyHoleRouteFavorited, loftRouteNotFavorited)
         )
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun itGetsResponsiveRoutesBySearchCriteriaAndWeather() = runTest {
-    }
+
+
 }

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -1,0 +1,116 @@
+package com.example.routesuggesterapp.data.repo
+
+import com.example.routesuggesterapp.data.db.FavoritedRouteDao
+import com.example.routesuggesterapp.data.network.Route
+import com.example.routesuggesterapp.data.network.RouteApi
+import com.example.routesuggesterapp.data.network.RouteApi.service
+import com.example.routesuggesterapp.data.network.RouteApiService
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.*
+
+class ResponsiveRouteRepoTest {
+    private lateinit var dao: FavoritedRouteDao
+    private lateinit var api: RouteApiService
+    private lateinit var repo: ResponsiveRouteRepo
+    private lateinit var longsPeakCriteria: RoutesSearchCriteria
+    private lateinit var keyHoleRoute: Route
+    private lateinit var loftRoute: Route
+    private lateinit var keyHoleRouteFavorited: ResponsiveRoute
+    private lateinit var loftRouteNotFavorited: ResponsiveRoute
+
+    @Before
+    fun initData() {
+        longsPeakCriteria = RoutesSearchCriteria(
+            Optional.empty(),
+            Optional.of("Longs Peak"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()
+        )
+
+        keyHoleRoute = Route(
+            1,
+            "Keyhole Route",
+            "Longs Peak",
+            true,
+            false,
+            3,
+            "Longs Peak Trailhead",
+            14256,
+            5100,
+            14,
+            "high",
+            "considerable",
+            "considerable",
+            "high",
+            1,
+            "thekeyholerouteiscool.com",
+            "longspeaktrailheadisgreat.com"
+        )
+        loftRoute = Route(
+            2,
+            "Loft Route",
+            "Longs Peak",
+            false,
+            false,
+            3,
+            "Longs Peak Trailhead",
+            14256,
+            5300,
+            13,
+            "high",
+            "considerable",
+            "high",
+            "high",
+            1,
+            "theloftrouteisfine.com",
+            "longspeaktrailheadisgreat.com"
+        )
+        keyHoleRouteFavorited = ResponsiveRoute(true, keyHoleRoute)
+        loftRouteNotFavorited = ResponsiveRoute(false, loftRoute)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun itGetsResponsiveRoutesBySearchCriteria() = runTest {
+        api = mock()
+        whenever(service.getRoutesBySearchCriteria(longsPeakCriteria)) doReturn listOf()
+        whenever(service.getRoutesBySearchCriteriaAndWeather(longsPeakCriteria)) doReturn listOf()
+
+        dao = mock()
+        whenever(dao.getRouteId(keyHoleRoute.id)) doReturn flow {
+            emit(keyHoleRoute.id)
+        }
+        whenever(dao.getRouteId(loftRoute.id)) doReturn emptyFlow()
+
+        repo = ResponsiveRouteRepo(dao, RouteApi)
+        assertEquals(
+            repo.getResponsiveRoutesBySearchCriteria(longsPeakCriteria),
+            listOf(keyHoleRouteFavorited, loftRouteNotFavorited)
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun itGetsResponsiveRoutesBySearchCriteriaAndWeather() = runTest {
+    }
+}


### PR DESCRIPTION
### Overall
ResponsiveRouteRepo serves as a single entry point for the ui-related classes, merging information from RouteApiService and FavoritedRouteDao to create domain object ResponsiveRoute, which has class fields of favorite and route. 

### ResponsiveRouteRepo build
I build out the class functions for ResponsiveRouteRepo. It's entry functions are getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) and getResponsiveRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria), which serve as a wrapper around the logic function buildListOfResponsiveRoutes(routes: List<Route>), which is unit testable. As seen in commit messages, I was having a hard time stubbing function output of RouteApi class field; I realized after some time I wouldn't need to anyways give function buildListOfResponsiveRoutes(routes: List<Route>), which is the output of RouteApi service calls, and removes duplicate code in previous commits. 

### ResponsiveRouteRepoTest build
This class tests two use cases of buildListOfResponsiveRoutes(routes: List<Route>) (given an empty list and non empty list, with the empty lists mapping to two different types) and mockito verification of favoriteRoute(route: Route) and unfavoriteRoute(route: Route). All functions tested are annotated with @VisibleForTesting in ResponsiveRouteRepo class.

### Other
I refactored Route to be a data class from an open class, and ResponsiveRoute has a Route as a field type, with hopes of dependency injection in the future. 