### PR TITLE
Dependency injection refractor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,8 +73,8 @@ dependencies {
     kapt("androidx.room:room-compiler:2.4.3")
     implementation "androidx.room:room-ktx:2.4.3"
 
-    implementation("com.google.dagger:hilt-android:2.41")
-    kapt("com.google.dagger:hilt-android-compiler:2.41")
+    implementation("com.google.dagger:hilt-android:2.43.2")
+    kapt("com.google.dagger:hilt-android-compiler:2.43.2")
 }
 
 kapt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -71,4 +72,11 @@ dependencies {
     // To use Kotlin annotation processing tool (kapt)
     kapt("androidx.room:room-compiler:2.4.3")
     implementation "androidx.room:room-ktx:2.4.3"
+
+    implementation("com.google.dagger:hilt-android:2.41")
+    kapt("com.google.dagger:hilt-android-compiler:2.41")
+}
+
+kapt {
+    correctErrorTypes = true
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.example.routesuggesterapp">
 
     <application
+        android:name=".RouteSuggesterApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:theme="@style/Theme.RouteSuggesterApp"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.elements.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
@@ -1,10 +1,69 @@
 package com.example.routesuggesterapp
 
 import android.app.Application
+import android.content.Context
+import androidx.room.Room
+import com.example.routesuggesterapp.data.db.FavoritedRouteDao
+import com.example.routesuggesterapp.data.db.FavoritedRouteDatabase
+import com.example.routesuggesterapp.data.network.RouteApiService
+import com.example.routesuggesterapp.data.repo.ResponsiveRouteRepo
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
 
 @Module
 @InstallIn(Application::class)
 object AppModule {
+    private const val BASE_URL = "https://restcountries.eu/rest/v2/"
+
+    @Singleton
+    @Provides
+    fun providesMoshi(kotlinJsonAdapterFactory: KotlinJsonAdapterFactory) : Moshi =
+        Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideMoshiConverterFactory(moshi: Moshi): MoshiConverterFactory =
+        MoshiConverterFactory.create(moshi)
+
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(moshiConverterFactory: MoshiConverterFactory): Retrofit =
+        Retrofit.Builder()
+        .addConverterFactory(moshiConverterFactory)
+        .baseUrl(BASE_URL)
+        .build()
+
+    @Singleton
+    @Provides
+    fun provideApiService(retrofit: Retrofit): RouteApiService =
+        retrofit.create(RouteApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideFavoritedRouteDatabase(@ApplicationContext app: Context) =
+        Room.databaseBuilder(
+        app,
+        FavoritedRouteDatabase::class.java,
+        "your_db_name"
+    ).build()
+
+    @Singleton
+    @Provides
+    fun provideFavoritedRouteDao(db: FavoritedRouteDatabase) =
+        db.favoritedRouteDao()
+
+    @Singleton
+    @Provides
+    fun providesResponsiveRouteRepo(dao: FavoritedRouteDao, apiService: RouteApiService) =
+        ResponsiveRouteRepo(dao, apiService)
 }

--- a/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
@@ -1,6 +1,5 @@
 package com.example.routesuggesterapp
 
-import android.app.Application
 import android.content.Context
 import androidx.room.Room
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
@@ -13,17 +12,18 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 @Module
-@InstallIn(Application::class)
+@InstallIn(SingletonComponent::class)
 object AppModule {
     private const val BASE_URL = "https://restcountries.eu/rest/v2/"
 
-    @Singleton
     @Provides
+    @Singleton
     fun providesMoshi() : Moshi =
         Moshi.Builder()
             .add(KotlinJsonAdapterFactory())

--- a/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
@@ -24,7 +24,7 @@ object AppModule {
 
     @Singleton
     @Provides
-    fun providesMoshi(kotlinJsonAdapterFactory: KotlinJsonAdapterFactory) : Moshi =
+    fun providesMoshi() : Moshi =
         Moshi.Builder()
             .add(KotlinJsonAdapterFactory())
             .build()

--- a/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
@@ -1,0 +1,10 @@
+package com.example.routesuggesterapp
+
+import android.app.Application
+import dagger.Module
+import dagger.hilt.InstallIn
+
+@Module
+@InstallIn(Application::class)
+object AppModule {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/AppModule.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-    private const val BASE_URL = "https://restcountries.eu/rest/v2/"
+    private const val BASE_URL = "a-url"
 
     @Provides
     @Singleton
@@ -54,7 +54,7 @@ object AppModule {
         Room.databaseBuilder(
         app,
         FavoritedRouteDatabase::class.java,
-        "your_db_name"
+            "favorited_route_database"
     ).build()
 
     @Singleton

--- a/app/src/main/java/com/example/routesuggesterapp/RouteSuggesterApplication.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/RouteSuggesterApplication.kt
@@ -1,0 +1,8 @@
+package com.example.routesuggesterapp
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class RouteSuggesterApplication : Application() {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/data/db/FavoritedRouteDatabase.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/db/FavoritedRouteDatabase.kt
@@ -1,8 +1,6 @@
 package com.example.routesuggesterapp.data.db
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 
 @Database(entities = [FavoritedRoute::class], version = 1, exportSchema = false)
@@ -10,22 +8,4 @@ abstract class FavoritedRouteDatabase : RoomDatabase() {
 
     abstract fun favoritedRouteDao(): FavoritedRouteDao
 
-    companion object {
-        @Volatile
-        private var INSTANCE: FavoritedRouteDatabase? = null
-
-        fun getDatabase(context: Context): FavoritedRouteDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    FavoritedRouteDatabase::class.java,
-                    "favorited_route_database"
-                )
-                    .fallbackToDestructiveMigration()
-                    .build()
-                INSTANCE = instance
-                return instance
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RouteApiService.kt
@@ -1,19 +1,6 @@
 package com.example.routesuggesterapp.data.network
 
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.POST
-
-private const val BASE_URL = "a-url"
-private val moshi = Moshi.Builder()
-    .add(KotlinJsonAdapterFactory())
-    .build()
-private val retrofit = Retrofit.Builder()
-    .addConverterFactory(MoshiConverterFactory.create(moshi))
-    .baseUrl(BASE_URL)
-    .build()
 
 interface RouteApiService {
 
@@ -23,9 +10,4 @@ interface RouteApiService {
     @POST("search/suggest_by_weather")
     suspend fun getRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<Route>
 
-}
-
-object RouteApi {
-    val service : RouteApiService by lazy {
-        retrofit.create(RouteApiService::class.java) }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -5,18 +5,19 @@ import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
 import com.example.routesuggesterapp.data.network.Route
 import com.example.routesuggesterapp.data.network.RouteApi
+import com.example.routesuggesterapp.data.network.RouteApiService
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import kotlinx.coroutines.flow.single
 
-class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: RouteApi) {
+class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: RouteApiService) {
 
     suspend fun getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
-        val routes = api.service.getRoutesBySearchCriteria(criteria)
+        val routes = api.getRoutesBySearchCriteria(criteria)
         return buildListOfResponsiveRoutes(routes)
     }
 
     suspend fun getResponsiveRoutesBySearchCriteriaAndWeather(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
-        val routes = api.service.getRoutesBySearchCriteriaAndWeather(criteria)
+        val routes = api.getRoutesBySearchCriteriaAndWeather(criteria)
         return buildListOfResponsiveRoutes(routes)
     }
 

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -7,8 +7,12 @@ import com.example.routesuggesterapp.data.network.Route
 import com.example.routesuggesterapp.data.network.RouteApiService
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import kotlinx.coroutines.flow.single
+import javax.inject.Inject
 
-class ResponsiveRouteRepo(private val dao: FavoritedRouteDao, private val api: RouteApiService) {
+class ResponsiveRouteRepo @Inject constructor(
+    private val dao: FavoritedRouteDao,
+    private val api: RouteApiService
+    ) {
 
     suspend fun getResponsiveRoutesBySearchCriteria(criteria: RoutesSearchCriteria) : List<ResponsiveRoute> {
         val routes = api.getRoutesBySearchCriteria(criteria)

--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -4,7 +4,6 @@ import androidx.annotation.VisibleForTesting
 import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
 import com.example.routesuggesterapp.data.network.Route
-import com.example.routesuggesterapp.data.network.RouteApi
 import com.example.routesuggesterapp.data.network.RouteApiService
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import kotlinx.coroutines.flow.single

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/FavoritesFragment.kt
@@ -6,17 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [FavoritesFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+@AndroidEntryPoint
 class FavoritesFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
@@ -6,17 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [FilterFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+@AndroidEntryPoint
 class FilterFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/HomeFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/HomeFragment.kt
@@ -6,17 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [HomeFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+@AndroidEntryPoint
 class HomeFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/MainActivity.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/MainActivity.kt
@@ -1,8 +1,11 @@
-package com.example.routesuggesterapp
+package com.example.routesuggesterapp.ui.elements
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/RouteFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/RouteFragment.kt
@@ -6,17 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [RouteFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+@AndroidEntryPoint
 class RouteFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/RouteListFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/RouteListFragment.kt
@@ -6,17 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.routesuggesterapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [RouteListFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+@AndroidEntryPoint
 class RouteListFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".ui.elements.MainActivity">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -3,10 +3,7 @@ package com.example.routesuggesterapp.data.repo
 import com.example.routesuggesterapp.data.db.FavoritedRoute
 import com.example.routesuggesterapp.data.db.FavoritedRouteDao
 import com.example.routesuggesterapp.data.network.Route
-import com.example.routesuggesterapp.data.network.RouteApi
-import com.example.routesuggesterapp.data.network.RouteApi.service
 import com.example.routesuggesterapp.data.network.RouteApiService
-import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
@@ -18,7 +15,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.*
 
 class ResponsiveRouteRepoTest {
     private lateinit var dao: FavoritedRouteDao

--- a/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepoTest.kt
@@ -22,6 +22,7 @@ import java.util.*
 
 class ResponsiveRouteRepoTest {
     private lateinit var dao: FavoritedRouteDao
+    private lateinit var apiService: RouteApiService
     private lateinit var repo: ResponsiveRouteRepo
     private lateinit var keyHoleRoute: Route
     private lateinit var loftRoute: Route
@@ -70,13 +71,15 @@ class ResponsiveRouteRepoTest {
         )
         keyHoleRouteFavorited = ResponsiveRoute(true, keyHoleRoute)
         loftRouteNotFavorited = ResponsiveRoute(false, loftRoute)
+
+        dao = mock()
+        apiService = mock()
+        repo = ResponsiveRouteRepo(dao, apiService)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun itBuildsAnEmptyListOfResponsiveRoutes() = runTest {
-        dao = mock()
-        repo = ResponsiveRouteRepo(dao, RouteApi)
         assertEquals(
             repo.buildListOfResponsiveRoutes(listOf()),
             listOf<ResponsiveRoute>()
@@ -86,13 +89,11 @@ class ResponsiveRouteRepoTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun itBuildsAListOfResponsiveRoutes() = runTest {
-        dao = mock()
         whenever(dao.getRouteId(keyHoleRoute.id)) doReturn flow {
             emit(keyHoleRoute.id)
         }
         whenever(dao.getRouteId(loftRoute.id)) doReturn emptyFlow()
 
-        repo = ResponsiveRouteRepo(dao, RouteApi)
         assertEquals(
             repo.buildListOfResponsiveRoutes(listOf(keyHoleRoute, loftRoute)),
             listOf(keyHoleRouteFavorited, loftRouteNotFavorited)
@@ -102,8 +103,6 @@ class ResponsiveRouteRepoTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun itFavoritesRouteByDao() = runTest{
-        dao = mock()
-        repo = ResponsiveRouteRepo(dao, RouteApi)
         repo.favoriteRoute(keyHoleRoute)
         verify(dao).insert(FavoritedRoute(routeId = keyHoleRoute.id))
     }
@@ -111,8 +110,6 @@ class ResponsiveRouteRepoTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun itUnFavoritesRouteByDao() = runTest {
-        dao = mock()
-        repo = ResponsiveRouteRepo(dao, RouteApi)
         repo.unfavoriteRoute(keyHoleRoute)
         verify(dao).delete(FavoritedRoute(routeId = keyHoleRoute.id))
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'com.android.application' version '7.2.1' apply false
     id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'com.google.dagger.hilt.android' version '2.41' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.android.application' version '7.2.1' apply false
     id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
-    id 'com.google.dagger.hilt.android' version '2.41' apply false
+    id 'com.google.dagger.hilt.android' version '2.43.2' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Following best practices, I looked to do a project refractor and use Hilt dependency injection library where applicable.

### RouteSuggesterApplicaiton Build & Activity/Fragment Annotation 
Hilt requires an anotated application class for entry. I built RouteSuggesterApplication, which implements Application, annotated with HiltAndroid app. All associated activities and fragments are thus annotated with @AndroidEntryPoint to add the appropraite DI container. The RouteSuggesterApplication class was added as the application name in the manifest. 

### AppModule build
This module is installed in the Singleton component, the injector for the application. All functions provide bindings for class constructors that cannot be injected. 

#### RouteFavoritedDatabase Interface
Database construction logic removed, as singleton instance is now created within an AppModule binding. 

#### RouteApiService Interface
RouteApi object removed, as singleton instance is now created within an AppModule binding. 

### ResponseRouteRepo Refractor
Constructor annotated with @Inject. Class fields refractored due RouteApiService refractor, and the constructor now takes a RouteApiService instance rather than RouteApi object. ResponsiveRouteRepoTest updated with change.

### Other
build.gradle files updated with most recent Hlit dependencies. 