### PR TITLE
ResponsiveRouteViewModel Class Construction/Fields

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/repo/ResponsiveRouteRepo.kt
@@ -24,6 +24,14 @@ class ResponsiveRouteRepo @Inject constructor(
         return buildListOfResponsiveRoutes(routes)
     }
 
+    suspend fun favoriteRoute(route: Route) {
+        dao.insert(FavoritedRoute(routeId = route.id))
+    }
+
+    suspend fun unfavoriteRoute(route: Route) {
+        dao.delete(FavoritedRoute(routeId = route.id))
+    }
+
     @VisibleForTesting
     suspend fun buildListOfResponsiveRoutes(routes: List<Route>) : List<ResponsiveRoute> {
         val listOfResponsiveRoutes = mutableListOf<ResponsiveRoute>()
@@ -36,16 +44,6 @@ class ResponsiveRouteRepo @Inject constructor(
             }
         }
         return listOfResponsiveRoutes
-    }
-
-    @VisibleForTesting
-    suspend fun favoriteRoute(route: Route) {
-        dao.insert(FavoritedRoute(routeId = route.id))
-    }
-
-    @VisibleForTesting
-    suspend fun unfavoriteRoute(route: Route) {
-        dao.delete(FavoritedRoute(routeId = route.id))
     }
 
     private suspend fun isRouteFavorited(route: Route) : Boolean {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
@@ -1,6 +1,9 @@
 package com.example.routesuggesterapp.ui.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.routesuggesterapp.data.repo.ResponsiveRoute
 import com.example.routesuggesterapp.data.repo.ResponsiveRouteRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -9,6 +12,9 @@ import javax.inject.Inject
 class ResponsiveRouteViewModel @Inject constructor(
     private val repo: ResponsiveRouteRepo
 ) : ViewModel() {
+    private val _routes = MutableLiveData<List<ResponsiveRoute>>()
+    val routes: LiveData<List<ResponsiveRoute>> = _routes
+
 
 
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
@@ -1,12 +1,14 @@
 package com.example.routesuggesterapp.ui.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.example.routesuggesterapp.data.repo.ResponsiveRoute
+import com.example.routesuggesterapp.data.repo.ResponsiveRouteRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class ResponsiveRouteViewModel : ViewModel() {
-    private val _routes = MutableLiveData<List<ResponsiveRoute>>()
-    val routes: LiveData<List<ResponsiveRoute>> = _routes
+@HiltViewModel
+class ResponsiveRouteViewModel @Inject constructor(
+    private val repo: ResponsiveRouteRepo
+) : ViewModel() {
+
 
 }


### PR DESCRIPTION
Not much happening here -

### ResponsiveRouteViewModel Class Construction/Fields
Following the previous PR #9, I annotated the class with @HiltViewModel, added the repo as a field in the private constructor, and kept the class fields of _routes and routes outside the di constuctor. This is a small PR because, as I was thinking about what this class should encapsulate, I realized I wanted to define my ui architecture differently:

1. I need another view model for my favorites fragment, and potentially a viewmodel for my home fragment
2. I wasn't sure how I wanted to bind data in the filter/route/route/routelist fragments, so I decided that my next set of tasts will be to work on the ui itself. The viewmodel classes would thus be the last steps in project construction. 
3. I was going back and forth whether the aforementioned fragments should share a common view model, each have their own, each have their own & share a common view model, etc, however; the navigation flow will encompass all three fragment, and thus their information is shared. For that reason, I'm going to have them all using the same shared view model (this one, which might be refractored with a new name"


### ResponsiveRouteRepo Re-Arranging Function Order
I realize this shouldn't have been part of this PR, but I re-ordered the functions from public to private, top-down.


