### PR TITLE
FilterFragmentAdapter Initial Dev

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -4,10 +4,10 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.example.routesuggesterapp.data.repo.ResponsiveRoute
+import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
 
 class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val mDiffer: AsyncListDiffer<ResponsiveRoute> = AsyncListDiffer(this, DiffCallback);
+    private val mDiffer: AsyncListDiffer<FilterViewType> = AsyncListDiffer(this, DiffCallback);
 
     override fun getItemCount() =
         mDiffer.currentList.size
@@ -21,16 +21,19 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     override fun getItemViewType(position: Int): Int {
-        return super.getItemViewType(position)
+        when (mDiffer.currentList[position]) {
+
+        }
+
     }
 
     companion object {
-        private val DiffCallback = object : DiffUtil.ItemCallback<ResponsiveRoute>() {
-            override fun areItemsTheSame(oldItem: ResponsiveRoute, newItem: ResponsiveRoute): Boolean {
-                return oldItem === newItem
+        private val DiffCallback = object : DiffUtil.ItemCallback<FilterViewType>() {
+            override fun areItemsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
+                TODO()
             }
 
-            override fun areContentsTheSame(oldItem: ResponsiveRoute, newItem: ResponsiveRoute): Boolean {
+            override fun areContentsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
                 TODO()
             }
         }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -1,0 +1,40 @@
+package com.example.routesuggesterapp.ui.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.example.routesuggesterapp.data.repo.ResponsiveRoute
+
+class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val  mDiffer: AsyncListDiffer<ResponsiveRoute> = AsyncListDiffer(this, DiffCallback);
+
+    override fun getItemCount() =
+        mDiffer.currentList.size
+
+    fun submitList(list: List<ResponsiveRoute>) {
+        mDiffer.submitList(list)
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val user = mDiffer.currentList[position]
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        TODO("Not yet implemented")
+    }
+
+
+    companion object {
+        private val DiffCallback = object : DiffUtil.ItemCallback<ResponsiveRoute>() {
+            override fun areItemsTheSame(oldItem: ResponsiveRoute, newItem: ResponsiveRoute): Boolean {
+                return oldItem === newItem
+            }
+
+            override fun areContentsTheSame(oldItem: ResponsiveRoute, newItem: ResponsiveRoute): Boolean {
+                TODO()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -4,23 +4,35 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.example.routesuggesterapp.data.repo.ResponsiveRoute
 import com.example.routesuggesterapp.databinding.FragmentRouteListBinding
+import com.example.routesuggesterapp.ui.adapter.models.ChipViewType
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
+import com.example.routesuggesterapp.ui.adapter.models.SliderViewType
+import com.example.routesuggesterapp.ui.adapter.models.SwitchViewType
+import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
 class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val mDiffer: AsyncListDiffer<FilterViewType> = AsyncListDiffer(this, DiffCallback);
 
-    override fun getItemCount() =
-        mDiffer.currentList.size
-
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val user = mDiffer.currentList[position]
+        val filterViewType = mDiffer.currentList[position]
+        when (filterViewType.viewType) {
+            ViewType.CHIP -> (holder as ChipViewHolder).bind(filterViewType as ChipViewType)
+            ViewType.SLIDER -> (holder as SliderViewHolder).bind(filterViewType as SliderViewType)
+            ViewType.SWITCH -> (holder as ChipViewHolder).bind(filterViewType as ChipViewType)
+            ViewType.TEXTFIELD -> (holder as TextFieldViewHolder).bind(filterViewType as TextFieldViewType)
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        TODO("Not yet implemented")
+        return when (viewType) {
+            CHIP_VAL -> ChipViewHolder(TODO())
+            SLIDER_VAL -> SliderViewHolder(TODO())
+            SWITCH_VAL -> SwitchViewHolder(TODO())
+            TEXTFIELD_VAL -> TextFieldViewHolder(TODO())
+            else -> {throw IllegalStateException("Unrecognized view type.")}
+        }
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -32,10 +44,13 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
+    override fun getItemCount() =
+        mDiffer.currentList.size
+
     class ChipViewHolder(private var binding: FragmentRouteListBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(responsiveRoute: ResponsiveRoute) {
+        fun bind(chipViewType: ChipViewType) {
             binding.apply {
                 TODO()
             }
@@ -45,7 +60,7 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     class SliderViewHolder(private var binding: FragmentRouteListBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(responsiveRoute: ResponsiveRoute) {
+        fun bind(sliderViewType: SliderViewType) {
             binding.apply {
                 TODO()
             }
@@ -55,17 +70,17 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     class SwitchViewHolder(private var binding: FragmentRouteListBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(responsiveRoute: ResponsiveRoute) {
+        fun bind(switchViewType: SwitchViewType) {
             binding.apply {
                 TODO()
             }
         }
     }
 
-    class TextViewHolder(private var binding: FragmentRouteListBinding) :
+    class TextFieldViewHolder(private var binding: FragmentRouteListBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(responsiveRoute: ResponsiveRoute) {
+        fun bind(textViewType: TextFieldViewType) {
             binding.apply {
                 TODO()
             }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -4,6 +4,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.example.routesuggesterapp.data.repo.ResponsiveRoute
+import com.example.routesuggesterapp.databinding.FragmentRouteListBinding
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
@@ -27,6 +29,46 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             ViewType.SLIDER -> SLIDER_VAL
             ViewType.SWITCH -> SWITCH_VAL
             ViewType.TEXTFIELD -> TEXTFIELD_VAL
+        }
+    }
+
+    class ChipViewHolder(private var binding: FragmentRouteListBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(responsiveRoute: ResponsiveRoute) {
+            binding.apply {
+                TODO()
+            }
+        }
+    }
+
+    class SliderViewHolder(private var binding: FragmentRouteListBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(responsiveRoute: ResponsiveRoute) {
+            binding.apply {
+                TODO()
+            }
+        }
+    }
+
+    class SwitchViewHolder(private var binding: FragmentRouteListBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(responsiveRoute: ResponsiveRoute) {
+            binding.apply {
+                TODO()
+            }
+        }
+    }
+
+    class TextViewHolder(private var binding: FragmentRouteListBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(responsiveRoute: ResponsiveRoute) {
+            binding.apply {
+                TODO()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -5,6 +5,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
+import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
 class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val mDiffer: AsyncListDiffer<FilterViewType> = AsyncListDiffer(this, DiffCallback);
@@ -21,10 +22,12 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     override fun getItemViewType(position: Int): Int {
-        when (mDiffer.currentList[position]) {
-
+        return when (mDiffer.currentList[position].viewType) {
+            ViewType.CHIP -> CHIP_VAL
+            ViewType.SLIDER -> SLIDER_VAL
+            ViewType.SWITCH -> SWITCH_VAL
+            ViewType.TEXTFIELD -> TEXTFIELD_VAL
         }
-
     }
 
     companion object {
@@ -37,6 +40,9 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 TODO()
             }
         }
+        const val CHIP_VAL = 0
+        const val SLIDER_VAL = 1
+        const val SWITCH_VAL = 2
+        const val TEXTFIELD_VAL = 3
     }
-
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -7,14 +7,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.routesuggesterapp.data.repo.ResponsiveRoute
 
 class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val  mDiffer: AsyncListDiffer<ResponsiveRoute> = AsyncListDiffer(this, DiffCallback);
+    private val mDiffer: AsyncListDiffer<ResponsiveRoute> = AsyncListDiffer(this, DiffCallback);
 
     override fun getItemCount() =
         mDiffer.currentList.size
-
-    fun submitList(list: List<ResponsiveRoute>) {
-        mDiffer.submitList(list)
-    }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val user = mDiffer.currentList[position]
@@ -24,6 +20,9 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         TODO("Not yet implemented")
     }
 
+    override fun getItemViewType(position: Int): Int {
+        return super.getItemViewType(position)
+    }
 
     companion object {
         private val DiffCallback = object : DiffUtil.ItemCallback<ResponsiveRoute>() {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterViewType.kt
@@ -1,0 +1,5 @@
+package com.example.routesuggesterapp.ui.adapter
+
+enum class FilterViewType {
+    CHIP, SWITCH, SLIDER, TEXT_FIELD
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterViewType.kt
@@ -1,5 +1,0 @@
-package com.example.routesuggesterapp.ui.adapter
-
-enum class FilterViewType {
-    CHIP, SWITCH, SLIDER, TEXT_FIELD
-}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
@@ -1,0 +1,4 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+class ChipViewType : FilterViewType() {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
@@ -1,5 +1,7 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class ChipViewType : FilterViewType() {
+class ChipViewType(
+    override val title: String,
+    val chipNames: List<String>) : FilterViewType() {
     override val viewType = ViewType.CHIP
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
@@ -1,4 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
 class ChipViewType : FilterViewType() {
+    override val viewType = ViewType.CHIP
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
@@ -1,0 +1,4 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+abstract class FilterViewType {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
@@ -1,4 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
 abstract class FilterViewType {
+    abstract val viewType: ViewType
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
@@ -2,4 +2,5 @@ package com.example.routesuggesterapp.ui.adapter.models
 
 abstract class FilterViewType {
     abstract val viewType: ViewType
+    abstract val title: String
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -1,4 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
 class SliderViewType : FilterViewType() {
+    override val viewType = ViewType.SLIDER
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -1,0 +1,4 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+class SliderViewType : FilterViewType() {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -1,5 +1,8 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class SliderViewType : FilterViewType() {
+class SliderViewType(
+    override val title: String,
+    val beginVal: Int,
+    val endVal: Int) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
@@ -1,4 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
 class SwitchViewType : FilterViewType() {
+    override val viewType = ViewType.SWITCH
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
@@ -1,0 +1,4 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+class SwitchViewType : FilterViewType() {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
@@ -1,5 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class SwitchViewType : FilterViewType() {
+class SwitchViewType(override val title: String) : FilterViewType() {
     override val viewType = ViewType.SWITCH
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
@@ -1,0 +1,4 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+class TextFieldViewType : FilterViewType() {
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
@@ -1,4 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
 class TextFieldViewType : FilterViewType() {
+    override val viewType = ViewType.TEXTFIELD
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
@@ -1,5 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class TextFieldViewType : FilterViewType() {
+class TextFieldViewType(override val title: String) : FilterViewType() {
     override val viewType = ViewType.TEXTFIELD
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ViewType.kt
@@ -1,0 +1,5 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+enum class ViewType {
+    CHIP, SLIDER, SWITCH, TEXTFIELD
+}


### PR DESCRIPTION
This serves as the adapter for filter fragment's recycler view.

### Motivation
I wasn't sure whether to do a LinearLayout or RecyclerView; however, as I am aware of, anytime there is a scrollable list that goes off-screen, RecyclerView usage is best practice. However, this would prove to be difficult; having more than one view type would mean I would need more than one ViewHolder type.

### Process
Unlike my codelabs, FilterFragmentAdapter extend sRecyclerView.Adapter rather than ListAdapter. From what I saw, I could cast different ViewHolder types when using RecyclerView.Adapter that didn't seem possible using ListAdapter (maybe an unfair assumption?). However, seeing examples online using multiple ViewHolders, I couldn't find any instances of ListAdapter. I used [AsyncListDiffer](https://developer.android.com/reference/androidx/recyclerview/widget/AsyncListDiffer) in the event the submitted list will be LiveData; if architecture decides otherwise, AsyncListDiffer will be deleted.

### FilterViewType abstract class & ViewType enum
There are 4 extended classes of FilterViewType: ChipViewType, SliderViewType, SwitchViewType, and TextBoxViewType. FilterViewType has two abstract fields - viewType: ViewType and tile: String. The enum class offers readability and  easy switch statements in the adapter - for databinding, the upcoming 4 layout files/views will serve as molds of similar-type RoutesSearchCriteria fields. 

### Chip/Slider/Switch/TextBoxViewHolder Inner Classes
Currently, the Binding class of each ViewHolder constructor is incorrect, as the layout files have not been created yet. However, this is serving as boilerplate for upcoming databinding.