### PR TITLE
FilterChipViewType Layout Dev

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,7 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
+        <entry key="app/src/main/res/layout/filter_chip_view_type.xml" value="0.5411684782608697" />
         <entry key="app/src/main/res/layout/fragment_favorites.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/fragment_filter.xml" value="0.49851116235705395" />
         <entry key="app/src/main/res/layout/fragment_route.xml" value="0.19610507246376813" />

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.example.routesuggesterapp.databinding.FilterChipViewTypeBinding
 import com.example.routesuggesterapp.databinding.FragmentRouteListBinding
 import com.example.routesuggesterapp.ui.adapter.models.ChipViewType
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
@@ -47,12 +48,13 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun getItemCount() =
         mDiffer.currentList.size
 
-    class ChipViewHolder(private var binding: FragmentRouteListBinding) :
+    class ChipViewHolder(private var binding: FilterChipViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(chipViewType: ChipViewType) {
             binding.apply {
-                TODO()
+                binding.chipViewType = chipViewType
+                //binding.executePendingBindings()
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
@@ -1,7 +1,5 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class ChipViewType(
-    override val title: String,
-    val chipNames: List<String>) : FilterViewType() {
+class ChipViewType(override val title: String) : FilterViewType() {
     override val viewType = ViewType.CHIP
 }

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:id="@+id/filterName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="Filter Name" />
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chipGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintTop_toTopOf="@id/filterName"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/low"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Low"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/moderate"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Moderate"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_3"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Moderate"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/high"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="High"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/extreme"
+                style="@style/Widget.MaterialComponents.Chip.Choice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Extreme"/>
+
+        </com.google.android.material.chip.ChipGroup>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -16,7 +16,7 @@
             android:layout_height="wrap_content"
             android:text=""
             android:textAppearance="?attr/textAppearanceHeadline6"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tools:text="Filter Name" />
@@ -25,8 +25,8 @@
             android:id="@+id/chipGroup"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:layout_marginBottom="16dp"
+            android:layout_marginTop="@string/filter_name_margin_top"
+            android:layout_marginBottom="@string/filter_margin_bottom"
             app:layout_constraintTop_toTopOf="@id/filterName"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">
@@ -37,7 +37,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="Low"/>
+                android:text="@string/chip_low"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/moderate"
@@ -45,15 +45,15 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="Moderate"/>
+                android:text="@string/chip_moderate"/>
 
             <com.google.android.material.chip.Chip
-                android:id="@+id/chip_3"
+                android:id="@+id/considerable"
                 style="@style/Widget.MaterialComponents.Chip.Choice"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="Moderate"/>
+                android:text="@string/considerable_chip"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/high"
@@ -61,7 +61,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="High"/>
+                android:text="@string/high_chip"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/extreme"
@@ -69,7 +69,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true"
-                android:text="Extreme"/>
+                android:text="@string/extreme_chip"/>
 
         </com.google.android.material.chip.ChipGroup>
 

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -4,6 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+        <variable
+            name="forageable"
+            type="com.example.routesuggesterapp.ui.adapter.models.ChipViewType" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="forageable"
+            name="chipViewType"
             type="com.example.routesuggesterapp.ui.adapter.models.ChipViewType" />
     </data>
 

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -20,12 +20,12 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text=""
+            android:text="@{chipViewType.title}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="Filter Name" />
+            tools:text="Exposure" />
 
         <com.google.android.material.chip.ChipGroup
             android:id="@+id/chipGroup"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,13 @@
 <resources>
     <string name="app_name">RouteSuggesterApp</string>
-    <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="chip_low">Low</string>
+    <string name="chip_moderate">Moderate</string>
+    <string name="considerable_chip">Considerable</string>
+    <string name="high_chip">High</string>
+    <string name="extreme_chip">Extreme</string>
+
+    <string name="filter_margin_top">16dp</string>
+    <string name="filter_margin_bottom">16dp</string>
+    <string name="filter_name_margin_top">32dp</string>
 </resources>


### PR DESCRIPTION
### filter_chip_view_type.xml Layout Dev
Following [Material chip implementation](https://material.io/components/chips/android#using-chips), I created a ChipGroup with 5 chips. These are statically implemented, as for any ChipViewType, there will always be Low/Moderate/Considerable/High/Extreme choices. These are [filter chips](https://material.io/components/chips/android#filter-chip), and thus have android:check="true" available. I use databinding in this file, such that an instance of chipViewType.title designates the TextView's android:text

#### String Resources
I pulled text fields of the chips into the string resource file. I also pulled out string resources for margins such that they will be constant across all filter layout files. 

### FilterFragmentAdapter Refractor
With the creation of filter_chip_view_type.xml, I refractored ChipViewBinding's constructor to have a field for FilterChipViewTypeBinding. I implemented the logic for bind(chipViewType: ChipViewType), which sets the given chipViewType for the binding's chipViewType. 

### ChipViewType Refractor
Initially, I didn't recognize the 5 chips would be static, so I had a field for chip names. Removed.

