### PR TITLE
FilterSliderViewType Layout Dev

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/filter_chip_view_type.xml" value="0.5411684782608697" />
-        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.575" />
+        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.5" />
         <entry key="app/src/main/res/layout/fragment_favorites.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/fragment_filter.xml" value="0.49851116235705395" />
         <entry key="app/src/main/res/layout/fragment_route.xml" value="0.19610507246376813" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/filter_chip_view_type.xml" value="0.5411684782608697" />
+        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.575" />
         <entry key="app/src/main/res/layout/fragment_favorites.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/fragment_filter.xml" value="0.49851116235705395" />
         <entry key="app/src/main/res/layout/fragment_route.xml" value="0.19610507246376813" />

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -5,6 +5,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.example.routesuggesterapp.databinding.FilterChipViewTypeBinding
+import com.example.routesuggesterapp.databinding.FilterSliderViewTypeBinding
 import com.example.routesuggesterapp.databinding.FragmentRouteListBinding
 import com.example.routesuggesterapp.ui.adapter.models.ChipViewType
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
@@ -59,12 +60,13 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
-    class SliderViewHolder(private var binding: FragmentRouteListBinding) :
+    class SliderViewHolder(private var binding: FilterSliderViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(sliderViewType: SliderViewType) {
             binding.apply {
-                TODO()
+                binding.sliderViewType = sliderViewType
+                //binding.executePendingsBindings()
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,7 +4,7 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
-    val initialSliderValues: IntArray) : FilterViewType() {
+    val initialSliderValues: List<Int>) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 
     init {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -2,7 +2,8 @@ package com.example.routesuggesterapp.ui.adapter.models
 
 class SliderViewType(
     override val title: String,
-    val beginVal: Int,
-    val endVal: Int) : FilterViewType() {
+    val valueFrom: Int,
+    val valueTo: Int,
+    val initialSliderValues: IntArray) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,6 +4,7 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
+    val stepSize: Int,
     val initialSliderValues: IntArray) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,7 +4,16 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
-    val stepSize: Int,
     val initialSliderValues: IntArray) : FilterViewType() {
     override val viewType = ViewType.SLIDER
+
+    init {
+        checkInitialSliderValuesSize()
+    }
+
+    private fun checkInitialSliderValuesSize() {
+        if (initialSliderValues.size != 2) {
+            throw IllegalStateException("Must provide an array of exactly two initial slider values.")
+        }
+    }
 }

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -28,6 +28,7 @@
             tools:text="Route Length" />
 
         <com.google.android.material.slider.RangeSlider
+            android:id="@+id/rangeSlider"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:layout_marginTop="@string/filter_name_margin_top"

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -27,7 +27,7 @@
             app:layout_constraintStart_toStartOf="parent"
             tools:text="Filter Name" />
 
-        <com.google.android.material.slider.Slider
+        <com.google.android.material.slider.RangeSlider
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:layout_marginTop="@string/filter_name_margin_top"

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -20,12 +20,12 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text=""
+            android:text="@{sliderViewType.title}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="Filter Name" />
+            tools:text="Route Length" />
 
         <com.google.android.material.slider.RangeSlider
             android:layout_height="wrap_content"
@@ -37,7 +37,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:valueFrom="0.0"
             android:valueTo="100.0"
-            android:stepSize="10.0" />
+             />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="sliderViewType"
+            type="com.example.routesuggesterapp.ui.adapter.models.SliderViewType" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:id="@+id/filterName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="@string/filter_margin_top"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="Filter Name" />
+
+        <com.google.android.material.slider.Slider
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_marginTop="@string/filter_name_margin_top"
+            android:layout_marginBottom="@string/filter_margin_bottom"
+            app:layout_constraintTop_toTopOf="@id/filterName"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:valueFrom="0.0"
+            android:valueTo="100.0"
+            android:stepSize="10.0" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -35,8 +35,9 @@
             app:layout_constraintTop_toTopOf="@id/filterName"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            android:valueFrom="0.0"
-            android:valueTo="100.0"
+            app:values="@{sliderViewType.initialSliderValues}"
+            android:valueFrom="@{sliderViewType.valueFrom}"
+            android:valueTo="@{sliderViewType.valueTo}"
              />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### filter_slider_view_type.xml Layout Dev
Following [Material chip implementation](https://material.io/components/sliders/android), I used a continuous range slider for my needs. I didn't need exact numbers (discrete slider), and I wanted a valueFrom and valueTo range. This will inevitably need a refractor for RoutesSearchCritiera, which has been updated in the Trello.
I used databinding for app:values, android:valueFrom, and android:valueTo of the RangeSlider. 

### FilterFragmentAdapter Refractor
With the creation of filter_slider_view_type.xml, I refractored SliderViewBinding's constructor to have a field for SliderChipViewTypeBinding. I implemented the logic for bind(sliderViewType: SliderViewType), which sets the given sliderViewType for the binding's sliderViewType.

### SliderViewType Refractor
I renamed the class fields to valueFrom and valueTo to follow the layout resource file verbiage. Also, there is a field for initial from/to values, which I added as a class field. I created a check such that this list should only be of size 2.
