### PR TITLE
FilterSwitchViewType Layout Dev

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,8 @@
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/filter_chip_view_type.xml" value="0.5411684782608697" />
-        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.5" />
+        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/filter_switch_view_type.xml" value="0.406036376953125" />
         <entry key="app/src/main/res/layout/fragment_favorites.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/fragment_filter.xml" value="0.49851116235705395" />
         <entry key="app/src/main/res/layout/fragment_route.xml" value="0.19610507246376813" />

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.example.routesuggesterapp.databinding.FilterChipViewTypeBinding
 import com.example.routesuggesterapp.databinding.FilterSliderViewTypeBinding
+import com.example.routesuggesterapp.databinding.FilterSwitchViewTypeBinding
 import com.example.routesuggesterapp.databinding.FragmentRouteListBinding
 import com.example.routesuggesterapp.ui.adapter.models.ChipViewType
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
@@ -71,12 +72,13 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
-    class SwitchViewHolder(private var binding: FragmentRouteListBinding) :
+    class SwitchViewHolder(private var binding: FilterSwitchViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(switchViewType: SwitchViewType) {
             binding.apply {
-                TODO()
+                binding.switchViewType = switchViewType
+                //binding.executePendingsBindings()
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
@@ -1,5 +1,8 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class SwitchViewType(override val title: String) : FilterViewType() {
+class SwitchViewType(
+    override val title: String,
+    val isChecked: Boolean,
+    ) : FilterViewType() {
     override val viewType = ViewType.SWITCH
 }

--- a/app/src/main/res/layout/filter_switch_view_type.xml
+++ b/app/src/main/res/layout/filter_switch_view_type.xml
@@ -37,7 +37,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_marginTop="@string/filter_margin_top"
             android:layout_marginBottom="@string/filter_margin_bottom"
-            android:checked="true" />
+            android:checked="@{switchViewType.checked}" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/filter_switch_view_type.xml
+++ b/app/src/main/res/layout/filter_switch_view_type.xml
@@ -30,6 +30,7 @@
             tools:text="Standard Routes Only" />
 
         <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/switchMaterial"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/filter_switch_view_type.xml
+++ b/app/src/main/res/layout/filter_switch_view_type.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="switchViewType"
+            type="com.example.routesuggesterapp.ui.adapter.models.SwitchViewType" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:id="@+id/filterName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{switchViewType.title}"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginTop="@string/filter_margin_top"
+            android:layout_marginBottom="@string/filter_margin_bottom"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="Standard Routes Only" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginTop="@string/filter_margin_top"
+            android:layout_marginBottom="@string/filter_margin_bottom"
+            android:checked="true" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
### filter_switch_view_type.xml Layout Dev
Following [Material switch implementation](https://material.io/components/switches/android#filter-chip), I added a slider for the RoutesSearchCriteria isSnowRoute and isStandardRoute. I used databinding for "@+id/filterName"'s android:text="@{switchViewType.title}" and android:id="@+id/switchMaterial"'s android:checked="@{switchViewType.checked}". isSnowRoute will be false, and isStandardRoute will be true. 

### FilterFragmentAdapter Refractor
With the creation of filter_switch_view_type.xml, I refractored SwitchViewBinding's constructor to have a field for SwitchViewTypeBinding. I implemented the logic for bind(switchViewType: SwitchViewType), which sets the given switchViewType for the binding's switchViewType.

### SwitchViewType Refractor
As mentioned above, the initial state of the slider is not constant. Thus, I added a constructor parameter isChecked: Boolean for databinding in the layout resource file. 