### PR TITLE
RangeSlider DataBinding Refractor

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,7 +4,7 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
-    val initialSliderValues: List<Int>) : FilterViewType() {
+    val initialSliderValues: MutableList<Float>) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 
     init {

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -39,6 +39,7 @@
             app:values="@{sliderViewType.initialSliderValues}"
             android:valueFrom="@{sliderViewType.valueFrom}"
             android:valueTo="@{sliderViewType.valueTo}"
+            android:value="@{sliderViewType.initialSliderValues"
              />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Build would fail due to incorrect databinding parameter of @id/rangeSlider app:values. Refractored SliderViewType class field initialSliderValues to MutableList<Float> for correction.