### PR TITLE
RoutesSearchCriteria Refractor & Unit Testing

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -1,39 +1,41 @@
 package com.example.routesuggesterapp.data.network
 
-class RoutesSearchCriteria private constructor (
-    val routeName: String?,
-    val mountainName: String?,
-    val sStandardRoute: Boolean?,
-    val isSnowRoute: Boolean?,
-    val grade: Int?,
-    val trailhead: String?,
-    val summitElevation: Int?,
-    val gain: Int?,
-    val length: Int?,
-    val exposure: String?,
-    val rockfallPotential: String?,
-    val routeFinding: String?,
-    val commitment: String?,
-    val roadDifficulty: Int?) {
+data class RoutesSearchCriteria constructor (
+    private val routeName: String?,
+    private val mountainName: String?,
+    private val sStandardRoute: Boolean?,
+    private val isSnowRoute: Boolean?,
+    private val grade: Int?,
+    private val trailhead: String?,
+    private val summitElevation: Int?,
+    private val gain: Int?,
+    private val length: Int?,
+    private val exposure: String?,
+    private val rockfallPotential: String?,
+    private val routeFinding: String?,
+    private val commitment: String?,
+    private val roadDifficulty: Int?) {
 
     data class Builder(
-        var routeName: String? = null,
-        var mountainName: String? = null,
-        var isStandardRoute: Boolean? = null,
-        var isSnowRoute: Boolean? = null,
-        var grade: Int? = null,
-        var trailhead: String? = null,
-        var summitElevation: Int? = null,
-        var gain: Int? = null,
-        var length: Int? = null,
-        var exposure: String? = null,
-        var rockfallPotential: String? = null,
-        var routeFinding: String? = null,
-        var commitment: String? = null,
-        var roadDifficulty: Int? = null
+        private var routeName: String? = null,
+        private var mountainName: String? = null,
+        private var isStandardRoute: Boolean? = null,
+        private var isSnowRoute: Boolean? = null,
+        private var grade: Int? = null,
+        private var trailhead: String? = null,
+        private var summitElevation: Int? = null,
+        private var gain: Int? = null,
+        private var length: Int? = null,
+        private var exposure: String? = null,
+        private var rockfallPotential: String? = null,
+        private var routeFinding: String? = null,
+        private var commitment: String? = null,
+        private var roadDifficulty: Int? = null
     ) {
 
-        fun routeName(routeName: String) = apply { this.routeName = routeName }
+        fun routeName(routeName: String) = apply {
+            this.routeName = routeName
+        }
 
         fun mountainName(mountainName: String) = apply { this.mountainName = mountainName }
 

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -5,37 +5,35 @@ data class RoutesSearchCriteria private constructor (
     val mountainName: String?,
     val isStandardRoute: Boolean?,
     val isSnowRoute: Boolean?,
-    val grade: Int?,
+    val grade: Pair<Int,Int>?,
     val trailhead: String?,
-    val summitElevation: Int?,
-    val gain: Int?,
-    val length: Int?,
+    val summitElevation: Pair<Int,Int>?,
+    val gain: Pair<Int,Int>?,
+    val length: Pair<Double,Double>?,
     val exposure: String?,
     val rockfallPotential: String?,
     val routeFinding: String?,
     val commitment: String?,
-    val roadDifficulty: Int?) {
+    val roadDifficulty: Pair<Int,Int>?) {
 
     data class Builder(
         private var routeName: String? = null,
         private var mountainName: String? = null,
         private var isStandardRoute: Boolean? = null,
         private var isSnowRoute: Boolean? = null,
-        private var grade: Int? = null,
+        private var grade: Pair<Int,Int>? = null,
         private var trailhead: String? = null,
-        private var summitElevation: Int? = null,
-        private var gain: Int? = null,
-        private var length: Int? = null,
+        private var summitElevation: Pair<Int,Int>? = null,
+        private var gain: Pair<Int,Int>? = null,
+        private var length: Pair<Double,Double>? = null,
         private var exposure: String? = null,
         private var rockfallPotential: String? = null,
         private var routeFinding: String? = null,
         private var commitment: String? = null,
-        private var roadDifficulty: Int? = null
+        private var roadDifficulty: Pair<Int,Int>? = null
     ) {
 
-        fun routeName(routeName: String) = apply {
-            this.routeName = routeName
-        }
+        fun routeName(routeName: String) = apply { this.routeName = routeName }
 
         fun mountainName(mountainName: String) = apply { this.mountainName = mountainName }
 
@@ -43,15 +41,15 @@ data class RoutesSearchCriteria private constructor (
 
         fun isSnowRoute(isSnowRoute: Boolean) = apply { this.isSnowRoute = isSnowRoute }
 
-        fun grade(grade: Int) = apply { this.grade = grade }
+        fun grade(grade: Pair<Int,Int>) = apply { this.grade = grade }
 
         fun trailhead(trailhead: String) = apply { this.trailhead = trailhead }
 
-        fun summitElevation(summitElevation: Int) = apply { this.summitElevation = summitElevation }
+        fun summitElevation(summitElevation: Pair<Int,Int>) = apply { this.summitElevation = summitElevation }
 
-        fun gain(gain: Int) = apply { this.gain = gain }
+        fun gain(gain: Pair<Int,Int>) = apply { this.gain = gain }
 
-        fun length(length: Int) = apply { this.length = length }
+        fun length(length: Pair<Double,Double>) = apply { this.length = length }
 
         fun exposure(exposure: String) = apply { this.exposure = exposure }
 
@@ -61,7 +59,7 @@ data class RoutesSearchCriteria private constructor (
 
         fun commitment(commitment: String) = apply { this.commitment = commitment }
 
-        fun roadDifficulty(roadDifficulty: Int) = apply { this.roadDifficulty = roadDifficulty}
+        fun roadDifficulty(roadDifficulty: Pair<Int,Int>) = apply { this.roadDifficulty = roadDifficulty}
 
         fun build() = RoutesSearchCriteria(routeName, mountainName, isStandardRoute, isSnowRoute, grade, trailhead, summitElevation, gain, length, exposure, rockfallPotential, routeFinding, commitment, roadDifficulty)
     }

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -10,10 +10,10 @@ data class RoutesSearchCriteria private constructor (
     val summitElevation: Pair<Int,Int>?,
     val gain: Pair<Int,Int>?,
     val length: Pair<Double,Double>?,
-    val exposure: String?,
-    val rockfallPotential: String?,
-    val routeFinding: String?,
-    val commitment: String?,
+    val exposure: List<String>?,
+    val rockfallPotential: List<String>?,
+    val routeFinding: List<String>?,
+    val commitment: List<String>?,
     val roadDifficulty: Pair<Int,Int>?) {
 
     data class Builder(
@@ -26,10 +26,10 @@ data class RoutesSearchCriteria private constructor (
         private var summitElevation: Pair<Int,Int>? = null,
         private var gain: Pair<Int,Int>? = null,
         private var length: Pair<Double,Double>? = null,
-        private var exposure: String? = null,
-        private var rockfallPotential: String? = null,
-        private var routeFinding: String? = null,
-        private var commitment: String? = null,
+        private var exposure: List<String>? = null,
+        private var rockfallPotential: List<String>? = null,
+        private var routeFinding: List<String>? = null,
+        private var commitment: List<String>? = null,
         private var roadDifficulty: Pair<Int,Int>? = null
     ) {
 
@@ -51,13 +51,13 @@ data class RoutesSearchCriteria private constructor (
 
         fun length(length: Pair<Double,Double>) = apply { this.length = length }
 
-        fun exposure(exposure: String) = apply { this.exposure = exposure }
+        fun exposure(exposure: List<String>) = apply { this.exposure = exposure }
 
-        fun rockfallPotential(rockfallPotential: String) = apply { this.rockfallPotential = rockfallPotential }
+        fun rockfallPotential(rockfallPotential: List<String>) = apply { this.rockfallPotential = rockfallPotential }
 
-        fun routeFinding(routeFinding: String) = apply { this.routeFinding = routeFinding}
+        fun routeFinding(routeFinding: List<String>) = apply { this.routeFinding = routeFinding}
 
-        fun commitment(commitment: String) = apply { this.commitment = commitment }
+        fun commitment(commitment: List<String>) = apply { this.commitment = commitment }
 
         fun roadDifficulty(roadDifficulty: Pair<Int,Int>) = apply { this.roadDifficulty = roadDifficulty}
 

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -1,20 +1,20 @@
 package com.example.routesuggesterapp.data.network
 
-data class RoutesSearchCriteria constructor (
-    private val routeName: String?,
-    private val mountainName: String?,
-    private val sStandardRoute: Boolean?,
-    private val isSnowRoute: Boolean?,
-    private val grade: Int?,
-    private val trailhead: String?,
-    private val summitElevation: Int?,
-    private val gain: Int?,
-    private val length: Int?,
-    private val exposure: String?,
-    private val rockfallPotential: String?,
-    private val routeFinding: String?,
-    private val commitment: String?,
-    private val roadDifficulty: Int?) {
+data class RoutesSearchCriteria private constructor (
+    val routeName: String?,
+    val mountainName: String?,
+    val isStandardRoute: Boolean?,
+    val isSnowRoute: Boolean?,
+    val grade: Int?,
+    val trailhead: String?,
+    val summitElevation: Int?,
+    val gain: Int?,
+    val length: Int?,
+    val exposure: String?,
+    val rockfallPotential: String?,
+    val routeFinding: String?,
+    val commitment: String?,
+    val roadDifficulty: Int?) {
 
     data class Builder(
         private var routeName: String? = null,

--- a/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
@@ -1,5 +1,6 @@
 package com.example.routesuggesterapp.data.network
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Before
 import org.junit.Test
@@ -19,5 +20,13 @@ class RoutesSearchCriteriaTest {
         builder.exposure("high")
         val criteria2 = builder.build()
         assertNotSame(criteria1, criteria2)
+    }
+
+    @Test
+    fun itCanUpdateBuilderClassFieldWithMultipleGetFunctionCalls() {
+        builder.exposure("high")
+        builder.exposure("low")
+        val criteria = builder.build()
+        assertEquals(criteria.exposure, "low")
     }
 }

--- a/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
@@ -1,0 +1,23 @@
+package com.example.routesuggesterapp.data.network
+
+import org.junit.Assert.assertNotSame
+import org.junit.Before
+import org.junit.Test
+
+class RoutesSearchCriteriaTest {
+    private lateinit var builder: RoutesSearchCriteria.Builder
+
+    @Before
+    fun initData() {
+        builder = RoutesSearchCriteria.Builder()
+    }
+
+    @Test
+    fun itCreatesAnImmutableRoutesSearchCriteria() {
+        builder.exposure("high")
+        val criteria1 = builder.build()
+        builder.exposure("high")
+        val criteria2 = builder.build()
+        assertNotSame(criteria1, criteria2)
+    }
+}


### PR DESCRIPTION
I refractored field types of RoutesSearchCriteria & RoutesSeachCriteria.Builder and tested immutability of the builder pattern.

### ```Pair<A,B>```
With the creation of the Views FilterViewType, SliderViewType (as referenced in filter_slider_view_type.xml), id.rangeSlider--as it's name suggests--uses a continuous range slider as ui. Thus, the criteria posted to my endpoints will be a pair of integers, rather than just one. Thus, I updated the field type of grade, summitElevation, gain, length, and road difficulty to Pair<A,B>

### ```List<String>```
Aforementioned, with ChipViewType creation (as referenced in filter_chip_view_type.xml), the user can query multiple chip strings. Again, the criteria posted to my endpoints will then be a list of Strings, rather than just one. I updated the field type of exposure, rockfall potential, route finding, and commitment to List<String>

### ```Double```
routeLength is a decimal-point value and should use double rather than int. 

### Unit Testing of RoutesSearchCriteria.Builder
I created two unit tests; one to test immutability of built RoutesSearchCriteria, and the other to test mutability of builder same-function calls. My test coverage only includes builder.exposure(exposure: List<String>), as I believe testing one function serves to represent the rest of the functions of RoutesSearchCriteria.Builder. I am comfortable with there being disagreement on this. The two test functions were created so test builder behavior as it relates to FilterFragmentAdapter view binding. 