### PR TITLE
FilterFragmentAdapter Dev

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/filter_chip_view_type.xml" value="0.5411684782608697" />
-        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/filter_slider_view_type.xml" value="0.2597396850585938" />
         <entry key="app/src/main/res/layout/filter_switch_view_type.xml" value="0.406036376953125" />
         <entry key="app/src/main/res/layout/filter_textbox_view_type.xml" value="0.335" />
         <entry key="app/src/main/res/layout/fragment_favorites.xml" value="0.19610507246376813" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    debugImplementation("androidx.fragment:fragment-testing:1.5.3")
+
 
     //Navigation
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
@@ -64,7 +66,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation("androidx.test.espresso:espresso-core:3.5.0-alpha07")
     implementation("app.cash.turbine:turbine:0.9.0")
 
     implementation("androidx.room:room-runtime:2.4.3")

--- a/app/src/androidTest/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapterTest.kt
+++ b/app/src/androidTest/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapterTest.kt
@@ -6,12 +6,17 @@ import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.routesuggesterapp.R
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
+import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
+import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.elements.FilterFragment
 import com.example.routesuggesterapp.ui.elements.MainActivity
+import com.google.android.material.textfield.TextInputEditText
 import org.hamcrest.Matcher
 import org.junit.Before
 import org.junit.Rule
@@ -26,7 +31,7 @@ class FilterFragmentAdapterTest {
        val scenario = launchFragmentInContainer<FilterFragment>()
     }
 
-    fun typeTextInChildViewWithId(id: Int, textToBeTyped: String): ViewAction {
+    fun typeTextInChildViewWithId(initInput: String, updatedInput: String): ViewAction {
         return object : ViewAction {
             override fun getConstraints(): Matcher<View>? {
                 TODO()

--- a/app/src/androidTest/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapterTest.kt
+++ b/app/src/androidTest/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapterTest.kt
@@ -1,0 +1,44 @@
+package com.example.routesuggesterapp.ui.adapter
+
+import android.view.View
+import android.widget.EditText
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.routesuggesterapp.R
+import com.example.routesuggesterapp.ui.elements.FilterFragment
+import com.example.routesuggesterapp.ui.elements.MainActivity
+import org.hamcrest.Matcher
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FilterFragmentAdapterTest {
+
+    @Before
+    fun setUp() {
+       val scenario = launchFragmentInContainer<FilterFragment>()
+    }
+
+    fun typeTextInChildViewWithId(id: Int, textToBeTyped: String): ViewAction {
+        return object : ViewAction {
+            override fun getConstraints(): Matcher<View>? {
+                TODO()
+            }
+
+            override fun getDescription(): String {
+                TODO()
+            }
+
+            override fun perform(uiController: UiController, view: View) {
+                TODO()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/BindingAdapters.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/BindingAdapters.kt
@@ -1,0 +1,14 @@
+package com.example.routesuggesterapp.ui.adapter
+
+
+import androidx.databinding.BindingAdapter
+import com.google.android.material.slider.RangeSlider
+
+object BindingAdapterUtils {
+    @JvmStatic
+    @BindingAdapter("app:values")
+    fun updateInitSliderValues(view: RangeSlider, initialSliderValues: List<Int>) {
+        initialSliderValues.map { it.toFloat() }
+        view.values = initialSliderValues.map { it.toFloat() }
+    }
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -12,6 +12,7 @@ import com.example.routesuggesterapp.databinding.FilterSwitchViewTypeBinding
 import com.example.routesuggesterapp.databinding.FilterTextFieldViewTypeBinding
 import com.example.routesuggesterapp.ui.adapter.models.ChipViewType
 import com.example.routesuggesterapp.ui.adapter.models.FilterViewType
+import com.example.routesuggesterapp.ui.adapter.models.FilterViewTypeList
 import com.example.routesuggesterapp.ui.adapter.models.SliderViewType
 import com.example.routesuggesterapp.ui.adapter.models.SwitchViewType
 import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
@@ -19,7 +20,7 @@ import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
 class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
     : ListAdapter<FilterViewType, RecyclerView.ViewHolder>(DiffCallback) {
-    private val dataSet: List<FilterViewType> = TODO()
+    lateinit var dataSet: List<FilterViewType>
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val filterViewType = dataSet[position]

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -3,6 +3,7 @@ package com.example.routesuggesterapp.ui.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.CompoundButton
+import androidx.core.view.forEach
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -18,6 +19,7 @@ import com.example.routesuggesterapp.ui.adapter.models.SliderViewType
 import com.example.routesuggesterapp.ui.adapter.models.SwitchViewType
 import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
+import com.google.android.material.chip.Chip
 
 class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
     : ListAdapter<FilterViewType, RecyclerView.ViewHolder>(DiffCallback) {
@@ -28,7 +30,7 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
         when (filterViewType.viewType) {
             ViewType.CHIP -> (holder as ChipViewHolder).bind(filterViewType as ChipViewType)
             ViewType.SLIDER -> (holder as SliderViewHolder).bind(filterViewType as SliderViewType)
-            ViewType.SWITCH -> (holder as ChipViewHolder).bind(filterViewType as ChipViewType)
+            ViewType.SWITCH -> (holder as SwitchViewHolder).bind(filterViewType as SwitchViewType)
             ViewType.TEXT_FIELD -> (holder as TextFieldViewHolder).bind(filterViewType as TextFieldViewType)
         }
     }
@@ -63,21 +65,19 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
             val chipList = mutableListOf<String>()
             binding.apply {
                 binding.chipViewType = chipViewType
-                low.setOnCheckedChangeListener{ chip, isChecked ->
-                    TODO()
-                }
-                moderate.setOnCheckedChangeListener { chip, isChecked ->
-                    TODO()
-                }
-                considerable.setOnCheckedChangeListener { chip, isChecked ->
-                    TODO()
-                }
-                high.setOnCheckedChangeListener { chip, isChecked ->
-                    TODO()
-                }
-                extreme.setOnCheckedChangeListener { chip, isChecked ->
-                    TODO()
-                }
+                low.setOnCheckedChangeListener(ChipListener(chipList))
+                moderate.setOnCheckedChangeListener(ChipListener(chipList))
+                considerable.setOnCheckedChangeListener(ChipListener(chipList))
+                high.setOnCheckedChangeListener(ChipListener(chipList))
+                extreme.setOnCheckedChangeListener(ChipListener(chipList))
+            }
+        }
+
+        inner class ChipListener(val chipList: MutableList<String>) : CompoundButton.OnCheckedChangeListener {
+            override fun onCheckedChanged(chip: CompoundButton?, isChecked: Boolean) {
+                val chipTitle = chip?.text.toString()
+                if (isChecked) chipList.add(chipTitle) else chipList.remove(chipTitle)
+                builder.exposure(chipList)
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -99,11 +99,11 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     companion object {
         private val DiffCallback = object : DiffUtil.ItemCallback<FilterViewType>() {
             override fun areItemsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                TODO()
+                return oldItem.title == newItem.title
             }
 
             override fun areContentsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                TODO()
+                return oldItem.title == newItem.title
             }
         }
         const val CHIP_VAL = 0

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -99,7 +99,9 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : Recycle
         fun bind(switchViewType: SwitchViewType) {
             binding.apply {
                 binding.switchViewType = switchViewType
-                //binding.executePendingsBindings()
+                switchMaterial.setOnCheckedChangeListener { switch, isChecked ->
+                    TODO()
+                }
             }
         }
     }
@@ -110,7 +112,8 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : Recycle
         fun bind(textFieldViewType: TextFieldViewType) {
             binding.apply {
                 binding.textFieldViewType = textFieldViewType
-                //binding.executePendingsBindings()
+                val inputText = filledTextField.editText?.text.toString()
+                TODO()
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -95,14 +95,14 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
         }
     }
 
-    class SwitchViewHolder(private var binding: FilterSwitchViewTypeBinding) :
+    inner class SwitchViewHolder(private var binding: FilterSwitchViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(switchViewType: SwitchViewType) {
             binding.apply {
                 binding.switchViewType = switchViewType
                 switchMaterial.setOnCheckedChangeListener { switch, isChecked ->
-                    TODO()
+                    if (isChecked) builder.isSnowRoute(true) else builder.isSnowRoute(false)
                 }
             }
         }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import com.example.routesuggesterapp.databinding.FilterChipViewTypeBinding
 import com.example.routesuggesterapp.databinding.FilterSliderViewTypeBinding
 import com.example.routesuggesterapp.databinding.FilterSwitchViewTypeBinding
@@ -16,7 +17,7 @@ import com.example.routesuggesterapp.ui.adapter.models.SwitchViewType
 import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
-class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val dataSet: List<FilterViewType> = TODO()
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -58,8 +59,23 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         fun bind(chipViewType: ChipViewType) {
             binding.apply {
                 binding.chipViewType = chipViewType
-                //binding.executePendingBindings()
+                low.setOnCheckedChangeListener { chip, isChecked ->
+                    TODO()
+                }
+                moderate.setOnCheckedChangeListener { chip, isChecked ->
+                    TODO()
+                }
+                considerable.setOnCheckedChangeListener { chip, isChecked ->
+                    TODO()
+                }
+                high.setOnCheckedChangeListener { chip, isChecked ->
+                    TODO()
+                }
+                extreme.setOnCheckedChangeListener { chip, isChecked ->
+                    TODO()
+                }
             }
+
         }
     }
 

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -17,10 +17,10 @@ import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
 class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val mDiffer: AsyncListDiffer<FilterViewType> = AsyncListDiffer(this, DiffCallback);
+    private val dataSet: List<FilterViewType> = TODO()
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val filterViewType = mDiffer.currentList[position]
+        val filterViewType = dataSet[position]
         when (filterViewType.viewType) {
             ViewType.CHIP -> (holder as ChipViewHolder).bind(filterViewType as ChipViewType)
             ViewType.SLIDER -> (holder as SliderViewHolder).bind(filterViewType as SliderViewType)
@@ -41,7 +41,7 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     override fun getItemViewType(position: Int): Int {
-        return when (mDiffer.currentList[position].viewType) {
+        return when (dataSet[position].viewType) {
             ViewType.CHIP -> CHIP_VAL
             ViewType.SLIDER -> SLIDER_VAL
             ViewType.SWITCH -> SWITCH_VAL
@@ -50,7 +50,7 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     override fun getItemCount() =
-        mDiffer.currentList.size
+        dataSet.size
 
     class ChipViewHolder(private var binding: FilterChipViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -97,15 +97,6 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     companion object {
-        private val DiffCallback = object : DiffUtil.ItemCallback<FilterViewType>() {
-            override fun areItemsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                return oldItem.title == newItem.title
-            }
-
-            override fun areContentsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                return oldItem.title == newItem.title
-            }
-        }
         const val CHIP_VAL = 0
         const val SLIDER_VAL = 1
         const val SWITCH_VAL = 2

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -55,9 +55,6 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
         }
     }
 
-    override fun getItemCount() =
-        dataSet.size
-
     inner class ChipViewHolder(private var binding: FilterChipViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
@@ -123,11 +120,11 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
     companion object {
         private val DiffCallback = object : DiffUtil.ItemCallback<FilterViewType>() {
             override fun areItemsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                TODO()
+                return oldItem == newItem
             }
 
             override fun areContentsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
-                TODO()
+                return oldItem.title == newItem.title
             }
         }
         const val CHIP_VAL = 0

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -2,6 +2,7 @@ package com.example.routesuggesterapp.ui.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.CompoundButton
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -55,13 +56,14 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
     override fun getItemCount() =
         dataSet.size
 
-    class ChipViewHolder(private var binding: FilterChipViewTypeBinding) :
+    inner class ChipViewHolder(private var binding: FilterChipViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(chipViewType: ChipViewType) {
+            val chipList = mutableListOf<String>()
             binding.apply {
                 binding.chipViewType = chipViewType
-                low.setOnCheckedChangeListener { chip, isChecked ->
+                low.setOnCheckedChangeListener{ chip, isChecked ->
                     TODO()
                 }
                 moderate.setOnCheckedChangeListener { chip, isChecked ->
@@ -77,19 +79,17 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
                     TODO()
                 }
             }
-
         }
     }
 
-    class SliderViewHolder(private var binding: FilterSliderViewTypeBinding) :
+    inner class SliderViewHolder(private var binding: FilterSliderViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(sliderViewType: SliderViewType) {
             binding.apply {
                 binding.sliderViewType = sliderViewType
-                rangeSlider.addOnChangeListener { slider, value, fromUser ->
-                    val values = rangeSlider.values
-                    TODO()
+                rangeSlider.addOnChangeListener { slider, _, _ ->
+                    builder.length(Pair(slider.values[0].toDouble(), slider.values[1].toDouble()))
                 }
             }
         }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -1,5 +1,6 @@
 package com.example.routesuggesterapp.ui.adapter
 
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
@@ -29,11 +30,12 @@ class FilterFragmentAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
         return when (viewType) {
-            CHIP_VAL -> ChipViewHolder(TODO())
-            SLIDER_VAL -> SliderViewHolder(TODO())
-            SWITCH_VAL -> SwitchViewHolder(TODO())
-            TEXTFIELD_VAL -> TextFieldViewHolder(TODO())
+            CHIP_VAL -> ChipViewHolder(FilterChipViewTypeBinding.inflate(layoutInflater, parent, false))
+            SLIDER_VAL -> SliderViewHolder(FilterSliderViewTypeBinding.inflate(layoutInflater, parent, false))
+            SWITCH_VAL -> SwitchViewHolder(FilterSwitchViewTypeBinding.inflate(layoutInflater, parent, false))
+            TEXTFIELD_VAL -> TextFieldViewHolder(FilterTextFieldViewTypeBinding.inflate(layoutInflater, parent, false))
             else -> {throw IllegalStateException("Unrecognized view type.")}
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -2,8 +2,8 @@ package com.example.routesuggesterapp.ui.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import com.example.routesuggesterapp.databinding.FilterChipViewTypeBinding
@@ -17,7 +17,8 @@ import com.example.routesuggesterapp.ui.adapter.models.SwitchViewType
 import com.example.routesuggesterapp.ui.adapter.models.TextFieldViewType
 import com.example.routesuggesterapp.ui.adapter.models.ViewType
 
-class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
+    : ListAdapter<FilterViewType, RecyclerView.ViewHolder>(DiffCallback) {
     private val dataSet: List<FilterViewType> = TODO()
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -119,6 +120,15 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : Recycle
     }
 
     companion object {
+        private val DiffCallback = object : DiffUtil.ItemCallback<FilterViewType>() {
+            override fun areItemsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
+                TODO()
+            }
+
+            override fun areContentsTheSame(oldItem: FilterViewType, newItem: FilterViewType): Boolean {
+                TODO()
+            }
+        }
         const val CHIP_VAL = 0
         const val SLIDER_VAL = 1
         const val SWITCH_VAL = 2

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -108,14 +108,14 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder)
         }
     }
 
-    class TextFieldViewHolder(private var binding: FilterTextFieldViewTypeBinding) :
+    inner class TextFieldViewHolder(private var binding: FilterTextFieldViewTypeBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(textFieldViewType: TextFieldViewType) {
             binding.apply {
                 binding.textFieldViewType = textFieldViewType
                 val inputText = filledTextField.editText?.text.toString()
-                TODO()
+                builder.routeName(inputText)
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/FilterFragmentAdapter.kt
@@ -85,7 +85,10 @@ class FilterFragmentAdapter(val builder: RoutesSearchCriteria.Builder) : Recycle
         fun bind(sliderViewType: SliderViewType) {
             binding.apply {
                 binding.sliderViewType = sliderViewType
-                //binding.executePendingsBindings()
+                rangeSlider.addOnChangeListener { slider, value, fromUser ->
+                    val values = rangeSlider.values
+                    TODO()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewTypeList.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewTypeList.kt
@@ -1,0 +1,5 @@
+package com.example.routesuggesterapp.ui.adapter.models
+
+object FilterViewTypeList {
+    val list = arrayListOf<FilterViewType>()
+}

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,7 +4,7 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
-    val initialSliderValues: MutableList<Float>) : FilterViewType() {
+    val initialSliderValues: List<Int>) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 
     init {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -4,7 +4,7 @@ class SliderViewType(
     override val title: String,
     val valueFrom: Int,
     val valueTo: Int,
-    val initialSliderValues: List<Int>) : FilterViewType() {
+    val initialSliderValues: MutableList<Float>) : FilterViewType() {
     override val viewType = ViewType.SLIDER
 
     init {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.routesuggesterapp.R
 import com.example.routesuggesterapp.databinding.FragmentFilterBinding
+import com.example.routesuggesterapp.ui.adapter.FilterFragmentAdapter
 import com.example.routesuggesterapp.ui.viewmodel.ResponsiveRouteViewModel
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,9 +25,13 @@ class FilterFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentFilterBinding.inflate(inflater, container, false)
-        val divider = MaterialDividerItemDecoration(requireContext(), LinearLayoutManager.HORIZONTAL)
-        binding.recyclerView.addItemDecoration(divider)
+        val adapter = FilterFragmentAdapter()
 
+        binding.apply {
+            recyclerView.adapter = adapter
+            val divider = MaterialDividerItemDecoration(requireContext(), LinearLayoutManager.HORIZONTAL)
+            recyclerView.addItemDecoration(divider)
+        }
         return binding.root
     }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
@@ -11,6 +11,7 @@ import com.example.routesuggesterapp.R
 import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import com.example.routesuggesterapp.databinding.FragmentFilterBinding
 import com.example.routesuggesterapp.ui.adapter.FilterFragmentAdapter
+import com.example.routesuggesterapp.ui.adapter.models.FilterViewTypeList
 import com.example.routesuggesterapp.ui.viewmodel.ResponsiveRouteViewModel
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,6 +28,7 @@ class FilterFragment : Fragment() {
     ): View? {
         binding = FragmentFilterBinding.inflate(inflater, container, false)
         val adapter = FilterFragmentAdapter(RoutesSearchCriteria.Builder())
+        adapter.dataSet = FilterViewTypeList.list
 
         binding.apply {
             recyclerView.adapter = adapter

--- a/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/elements/FilterFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.routesuggesterapp.R
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import com.example.routesuggesterapp.databinding.FragmentFilterBinding
 import com.example.routesuggesterapp.ui.adapter.FilterFragmentAdapter
 import com.example.routesuggesterapp.ui.viewmodel.ResponsiveRouteViewModel
@@ -25,7 +26,7 @@ class FilterFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentFilterBinding.inflate(inflater, container, false)
-        val adapter = FilterFragmentAdapter()
+        val adapter = FilterFragmentAdapter(RoutesSearchCriteria.Builder())
 
         binding.apply {
             recyclerView.adapter = adapter

--- a/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/viewmodel/ResponsiveRouteViewModel.kt
@@ -3,6 +3,7 @@ package com.example.routesuggesterapp.ui.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.routesuggesterapp.data.network.RoutesSearchCriteria
 import com.example.routesuggesterapp.data.repo.ResponsiveRoute
 import com.example.routesuggesterapp.data.repo.ResponsiveRouteRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,5 +15,11 @@ class ResponsiveRouteViewModel @Inject constructor(
 ) : ViewModel() {
     private val _routes = MutableLiveData<List<ResponsiveRoute>>()
     val routes: LiveData<List<ResponsiveRoute>> = _routes
+
+    private val _searchCriteria = MutableLiveData<RoutesSearchCriteria>()
+    val searchCriteria: LiveData<RoutesSearchCriteria> = _searchCriteria
+
+    fun updateSearchCriteria(builder: RoutesSearchCriteria.Builder) =
+        builder.build()
 
 }

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -39,7 +39,6 @@
             app:values="@{sliderViewType.initialSliderValues}"
             android:valueFrom="@{sliderViewType.valueFrom}"
             android:valueTo="@{sliderViewType.valueTo}"
-            android:value="@{sliderViewType.initialSliderValues"
              />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
@@ -15,18 +15,18 @@ class RoutesSearchCriteriaTest {
 
     @Test
     fun itCreatesAnImmutableRoutesSearchCriteria() {
-        builder.exposure("high")
+        builder.exposure(listOf("high"))
         val criteria1 = builder.build()
-        builder.exposure("high")
+        builder.exposure(listOf("high"))
         val criteria2 = builder.build()
         assertNotSame(criteria1, criteria2)
     }
 
     @Test
     fun itCanUpdateBuilderClassFieldWithMultipleGetFunctionCalls() {
-        builder.exposure("high")
-        builder.exposure("low")
+        builder.exposure(listOf("high"))
+        builder.exposure(listOf("low"))
         val criteria = builder.build()
-        assertEquals(criteria.exposure, "low")
+        assertEquals(criteria.exposure, listOf("low"))
     }
 }


### PR DESCRIPTION
This PR encapsulates the continued development of the FilterFragment adapter class, including logic refractor of its inner ViewHolder classes and implementation in FilterFragment and instrumentation test codel 

### ViewHolder classes Refractor
I updated the logic of the bind methods of each ViewHolder inner class. That being said, this logic is not finished: in  the next PR, I will need to refractor the RoutesSearchCriteria.Builder. There are four container classes for each FilterViewType, however; there are 14 fields of RoutesSearchCriteria, so I will need custom setters for the build design pattern. 
Note: the classes had not previously been modified with "inner", and I updated so that each class could implement the outer classes's members. 

### Filter Fragment Dev & FilterViewTypeList object build
I instantiated a FilterFragmentAdapter in the onCreateView() of FilterFragment. I created a boilerplate object FilterViewTypeList to be injected as the dataSet field in FilterFragmentAdapter. 

### ResponsiveRouteViewModel Dev
I added a few class fields & one function to mentally complete the process flow of RoutesSearchCriteria and the FilterFragmentAdapter. This is subject for much change. 

### FilterFragmentAdapter Instrumentation Test
This is just the boilerplate of the instrumentation tests to be run when I have more ui. 

### BindingAdapterUtils Build
I had recently thought that my builds kept failing because of app:values="@{sliderViewType.initialSliderValues} of the range slider, however; I did not realize I had accidentally added another field android:values="@{sliderViewType.initialSliderValues}. Thus, I created a binding adapter for the later field, not knowing that it was an incorrect declaration in the layout file. I did having custom binding adapter, however; it meant that the initialSliderValues field of SliderViewType did not have to be a MutableList<Float>. Rather, the constructor more obviously takes a List<Int> for readability. 


