### PR TITLE
RoutesSearchCriteria.Builder Refractor

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
@@ -1,0 +1,25 @@
+package com.example.routesuggesterapp.data.network
+
+enum class Criteria {
+    ROUTE_NAME, MOUNTAIN_NAME, IS_STANDARD_ROUTE, IS_SNOW_ROUTE, GRADE, TRAILHEAD, SUMMIT_ELEVATION,
+    GAIN, LENGTH, EXPOSURE, ROCKFALL_POTENTIAL, ROUTE_FINDING, COMMITMENT, ROAD_DIFFICULTY;
+
+    override fun toString(): String {
+       return when (this) {
+           ROUTE_NAME -> "Route Name"
+           MOUNTAIN_NAME -> "Mountain Name"
+           IS_STANDARD_ROUTE -> "Standard Route Only"
+           IS_SNOW_ROUTE -> "Snow Route Only"
+           GRADE -> "Grade"
+           TRAILHEAD -> "Trailhead"
+           SUMMIT_ELEVATION -> "Summit Elevation"
+           GAIN -> "Gain"
+           LENGTH -> "Length"
+           EXPOSURE -> "Exposure"
+           ROCKFALL_POTENTIAL -> "Rockfall Potential"
+           ROUTE_FINDING -> "Route Finding"
+           COMMITMENT -> "Commitment"
+           ROAD_DIFFICULTY -> "Road Difficulty"
+       }
+    }
+}

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
@@ -4,6 +4,25 @@ enum class Criteria {
     ROUTE_NAME, MOUNTAIN_NAME, IS_STANDARD_ROUTE, IS_SNOW_ROUTE, GRADE, TRAILHEAD, SUMMIT_ELEVATION,
     GAIN, LENGTH, EXPOSURE, ROCKFALL_POTENTIAL, ROUTE_FINDING, COMMITMENT, ROAD_DIFFICULTY;
 
+    override fun toString(): String {
+        return when (this) {
+            ROUTE_NAME -> "Route Name"
+            MOUNTAIN_NAME -> "Mountain Name"
+            IS_STANDARD_ROUTE -> "Standard Route Only"
+            IS_SNOW_ROUTE ->  "Snow Route Only"
+            GRADE -> "Grade"
+            TRAILHEAD -> "Trailhead"
+            SUMMIT_ELEVATION -> "Summit Elevation"
+            GAIN -> "Gain"
+            LENGTH -> "Length"
+            EXPOSURE -> "Exposure"
+            ROCKFALL_POTENTIAL -> "Rockfall Potential"
+            ROUTE_FINDING -> "Route Finding"
+            COMMITMENT -> "Commitment"
+            ROAD_DIFFICULTY -> "Road Difficulty"
+        }
+    }
+
     fun fromString(criteria: String): Criteria {
        return when (criteria) {
            "Route Name" -> ROUTE_NAME

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/Criteria.kt
@@ -4,22 +4,23 @@ enum class Criteria {
     ROUTE_NAME, MOUNTAIN_NAME, IS_STANDARD_ROUTE, IS_SNOW_ROUTE, GRADE, TRAILHEAD, SUMMIT_ELEVATION,
     GAIN, LENGTH, EXPOSURE, ROCKFALL_POTENTIAL, ROUTE_FINDING, COMMITMENT, ROAD_DIFFICULTY;
 
-    override fun toString(): String {
-       return when (this) {
-           ROUTE_NAME -> "Route Name"
-           MOUNTAIN_NAME -> "Mountain Name"
-           IS_STANDARD_ROUTE -> "Standard Route Only"
-           IS_SNOW_ROUTE -> "Snow Route Only"
-           GRADE -> "Grade"
-           TRAILHEAD -> "Trailhead"
-           SUMMIT_ELEVATION -> "Summit Elevation"
-           GAIN -> "Gain"
-           LENGTH -> "Length"
-           EXPOSURE -> "Exposure"
-           ROCKFALL_POTENTIAL -> "Rockfall Potential"
-           ROUTE_FINDING -> "Route Finding"
-           COMMITMENT -> "Commitment"
-           ROAD_DIFFICULTY -> "Road Difficulty"
+    fun fromString(criteria: String): Criteria {
+       return when (criteria) {
+           "Route Name" -> ROUTE_NAME
+           "Mountain Name" -> MOUNTAIN_NAME
+           "Standard Route Only" -> IS_STANDARD_ROUTE
+           "Snow Route Only" -> IS_SNOW_ROUTE
+           "Grade" -> GRADE
+           "Trailhead" -> TRAILHEAD
+           "Summit Elevation" -> SUMMIT_ELEVATION
+           "Gain" -> GAIN
+           "Length" -> LENGTH
+           "Exposure" -> EXPOSURE
+           "Rockfall Potential" -> ROCKFALL_POTENTIAL
+           "Route Finding" -> ROUTE_FINDING
+           "Commitment" -> COMMITMENT
+           "Road Difficulty" -> ROAD_DIFFICULTY
+           else -> throw IllegalArgumentException("Provided criteria string is not an enum Criteria member.")
        }
     }
 }

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -21,46 +21,82 @@ data class RoutesSearchCriteria private constructor (
         private var mountainName: String? = null,
         private var isStandardRoute: Boolean? = null,
         private var isSnowRoute: Boolean? = null,
-        private var grade: Pair<Int,Int>? = null,
+        private var grade: Pair<Int, Int>? = null,
         private var trailhead: String? = null,
-        private var summitElevation: Pair<Int,Int>? = null,
-        private var gain: Pair<Int,Int>? = null,
-        private var length: Pair<Double,Double>? = null,
+        private var summitElevation: Pair<Int, Int>? = null,
+        private var gain: Pair<Int, Int>? = null,
+        private var length: Pair<Double, Double>? = null,
         private var exposure: List<String>? = null,
         private var rockfallPotential: List<String>? = null,
         private var routeFinding: List<String>? = null,
         private var commitment: List<String>? = null,
-        private var roadDifficulty: Pair<Int,Int>? = null
+        private var roadDifficulty: Pair<Int, Int>? = null
     ) {
 
-        fun routeName(routeName: String) = apply { this.routeName = routeName }
+        fun applyCriteriaByChip(criteria: Criteria, checkedChips: List<String>) {
+            apply {
+                when (criteria) {
+                    Criteria.EXPOSURE -> exposure = checkedChips
+                    Criteria.ROCKFALL_POTENTIAL -> rockfallPotential = checkedChips
+                    Criteria.ROUTE_FINDING -> routeFinding = checkedChips
+                    Criteria.COMMITMENT -> commitment = checkedChips
+                    else -> throw IllegalStateException("Not an instance of a chip view type")
+                }
+            }
+        }
 
-        fun mountainName(mountainName: String) = apply { this.mountainName = mountainName }
+        fun applyCriteriaBySlider(criteria: Criteria, values: MutableList<Float>) {
+            val valuesAsIntPair = Pair(values[0].toInt(), values[0].toInt())
+            val valuesAsDoublePair = Pair(values[0].toDouble(), values[0].toDouble())
+            apply {
+                when (criteria) {
+                    Criteria.GRADE -> grade = valuesAsIntPair
+                    Criteria.SUMMIT_ELEVATION -> summitElevation = valuesAsIntPair
+                    Criteria.GAIN -> gain = valuesAsIntPair
+                    Criteria.LENGTH -> length = valuesAsDoublePair
+                    Criteria.ROAD_DIFFICULTY -> roadDifficulty = valuesAsIntPair
+                    else -> throw IllegalStateException("Not an instance of a slider view type")
+                }
+            }
+        }
 
-        fun isStandardRoute(isStandardRoute: Boolean) = apply { this.isStandardRoute = isStandardRoute }
+        fun applyCriteriaBySwitch(criteria: Criteria, isChecked: Boolean) {
+            apply {
+                when (criteria) {
+                    Criteria.IS_STANDARD_ROUTE -> isStandardRoute = isChecked
+                    Criteria.IS_SNOW_ROUTE -> isSnowRoute = isChecked
+                    else -> throw IllegalStateException("Not an instance of a switch view type")
+                }
+            }
+        }
 
-        fun isSnowRoute(isSnowRoute: Boolean) = apply { this.isSnowRoute = isSnowRoute }
+        fun applyCriteriaByTextField(criteria: Criteria, text: String) {
+            apply {
+                when (criteria) {
+                    Criteria.ROUTE_NAME -> routeName = text
+                    Criteria.MOUNTAIN_NAME -> mountainName = text
+                    Criteria.TRAILHEAD -> trailhead = text
+                    else -> throw IllegalStateException("Not an instance of a text field view type")
+                }
+            }
+        }
 
-        fun grade(grade: Pair<Int,Int>) = apply { this.grade = grade }
-
-        fun trailhead(trailhead: String) = apply { this.trailhead = trailhead }
-
-        fun summitElevation(summitElevation: Pair<Int,Int>) = apply { this.summitElevation = summitElevation }
-
-        fun gain(gain: Pair<Int,Int>) = apply { this.gain = gain }
-
-        fun length(length: Pair<Double,Double>) = apply { this.length = length }
-
-        fun exposure(exposure: List<String>) = apply { this.exposure = exposure }
-
-        fun rockfallPotential(rockfallPotential: List<String>) = apply { this.rockfallPotential = rockfallPotential }
-
-        fun routeFinding(routeFinding: List<String>) = apply { this.routeFinding = routeFinding}
-
-        fun commitment(commitment: List<String>) = apply { this.commitment = commitment }
-
-        fun roadDifficulty(roadDifficulty: Pair<Int,Int>) = apply { this.roadDifficulty = roadDifficulty}
-
-        fun build() = RoutesSearchCriteria(routeName, mountainName, isStandardRoute, isSnowRoute, grade, trailhead, summitElevation, gain, length, exposure, rockfallPotential, routeFinding, commitment, roadDifficulty)
+        fun build() = RoutesSearchCriteria(
+            routeName,
+            mountainName,
+            isStandardRoute,
+            isSnowRoute,
+            grade,
+            trailhead,
+            summitElevation,
+            gain,
+            length,
+            exposure,
+            rockfallPotential,
+            routeFinding,
+            commitment,
+            roadDifficulty
+        )
     }
 }
+

--- a/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteria.kt
@@ -46,8 +46,8 @@ data class RoutesSearchCriteria private constructor (
         }
 
         fun applyCriteriaBySlider(criteria: Criteria, values: MutableList<Float>) {
-            val valuesAsIntPair = Pair(values[0].toInt(), values[0].toInt())
-            val valuesAsDoublePair = Pair(values[0].toDouble(), values[0].toDouble())
+            val valuesAsIntPair = Pair(values[0].toInt(), values[1].toInt())
+            val valuesAsDoublePair = Pair(values[0].toDouble(), values[1].toDouble())
             apply {
                 when (criteria) {
                     Criteria.GRADE -> grade = valuesAsIntPair

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/ChipViewType.kt
@@ -1,5 +1,7 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
-class ChipViewType(override val title: String) : FilterViewType() {
+import com.example.routesuggesterapp.data.network.Criteria
+
+class ChipViewType(override val title: Criteria) : FilterViewType() {
     override val viewType = ViewType.CHIP
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewType.kt
@@ -1,6 +1,8 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
+import com.example.routesuggesterapp.data.network.Criteria
+
 abstract class FilterViewType {
     abstract val viewType: ViewType
-    abstract val title: String
+    abstract val title: Criteria
 }

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SliderViewType.kt
@@ -1,7 +1,9 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
+import com.example.routesuggesterapp.data.network.Criteria
+
 class SliderViewType(
-    override val title: String,
+    override val title: Criteria,
     val valueFrom: Int,
     val valueTo: Int,
     val initialSliderValues: List<Int>) : FilterViewType() {

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/SwitchViewType.kt
@@ -1,7 +1,9 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
+import com.example.routesuggesterapp.data.network.Criteria
+
 class SwitchViewType(
-    override val title: String,
+    override val title: Criteria,
     val isChecked: Boolean,
     ) : FilterViewType() {
     override val viewType = ViewType.SWITCH

--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/TextFieldViewType.kt
@@ -1,7 +1,9 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
+import com.example.routesuggesterapp.data.network.Criteria
+
 class TextFieldViewType(
-    override val title: String,
+    override val title: Criteria,
     val editTextFieldHint: String
     ) : FilterViewType() {
     override val viewType = ViewType.TEXT_FIELD

--- a/app/src/main/res/layout/filter_chip_view_type.xml
+++ b/app/src/main/res/layout/filter_chip_view_type.xml
@@ -20,7 +20,7 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{chipViewType.title}"
+            android:text="@{chipViewType.title.toString()}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/filter_slider_view_type.xml
+++ b/app/src/main/res/layout/filter_slider_view_type.xml
@@ -20,7 +20,7 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{sliderViewType.title}"
+            android:text="@{sliderViewType.title.toString()}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/filter_switch_view_type.xml
+++ b/app/src/main/res/layout/filter_switch_view_type.xml
@@ -20,7 +20,7 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{switchViewType.title}"
+            android:text="@{switchViewType.title.toString()}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             android:layout_marginBottom="@string/filter_margin_bottom"

--- a/app/src/main/res/layout/filter_text_field_view_type.xml
+++ b/app/src/main/res/layout/filter_text_field_view_type.xml
@@ -20,7 +20,7 @@
             android:id="@+id/filterName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{textFieldViewType.title}"
+            android:text="@{textFieldViewType.title.toString()}"
             android:textAppearance="?attr/textAppearanceHeadline6"
             android:layout_marginTop="@string/filter_margin_top"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
+++ b/app/src/test/java/com/example/routesuggesterapp/data/network/RoutesSearchCriteriaTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Before
 import org.junit.Test
+import java.lang.IllegalStateException
 
 class RoutesSearchCriteriaTest {
     private lateinit var builder: RoutesSearchCriteria.Builder
@@ -15,18 +16,39 @@ class RoutesSearchCriteriaTest {
 
     @Test
     fun itCreatesAnImmutableRoutesSearchCriteria() {
-        builder.exposure(listOf("high"))
+        builder.applyCriteriaByChip(Criteria.EXPOSURE, listOf("high"))
         val criteria1 = builder.build()
-        builder.exposure(listOf("high"))
+        builder.applyCriteriaByChip(Criteria.EXPOSURE, listOf("high"))
         val criteria2 = builder.build()
         assertNotSame(criteria1, criteria2)
     }
 
     @Test
     fun itCanUpdateBuilderClassFieldWithMultipleGetFunctionCalls() {
-        builder.exposure(listOf("high"))
-        builder.exposure(listOf("low"))
+        builder.applyCriteriaByChip(Criteria.EXPOSURE, listOf("high"))
+        builder.applyCriteriaByChip(Criteria.EXPOSURE, listOf("high", "low"))
         val criteria = builder.build()
-        assertEquals(criteria.exposure, listOf("low"))
+        assertEquals(criteria.exposure, listOf("high", "low"))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun itThrowsIllegalStateExceptionWhenProvidedWrongCriteriaByChip() {
+        builder.applyCriteriaByChip(Criteria.ROUTE_NAME, listOf("low"))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun itThrowsIllegalStateExceptionWhenProvidedWrongCriteriaBySlider() {
+        java.lang.Float(100.0)
+        builder.applyCriteriaBySlider(Criteria.ROUTE_NAME, mutableListOf(1f, 2f))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun itThrowsIllegalStateExceptionWhenProvidedWrongCriteriaBySwitch() {
+        builder.applyCriteriaBySwitch(Criteria.ROUTE_NAME, false)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun itThrowsIllegalStateExceptionWhenProvidedWrongCriteriaByTextField() {
+        builder.applyCriteriaByTextField(Criteria.EXPOSURE, "Long's Peak")
     }
 }


### PR DESCRIPTION
### RoutesSearchCriteria.Builder Refractor
The previous builder pattern clashed with the binding functions of FilterFragmentAdapter's ViewHolder inner classes. As in, because I have four containers of FilterViewType, yet 14~ apply functions of RoutesSearchCriteria.Builder, there was no way to tell which of those function should be called when. Thus, in RoutesSearchCriteria.Builder, I created four wrapper functions as correlated with each FilterViewType. However, I noticed this ambiguity might lead to bugs down the line; each FilterViewType has a title, and that title would call the correct Builder setter. This String comparison is pretty vulnerable. Because of this, to erase ambiguity, I created a....

### Enum Class Criteria Build
Aforementioned, this eliminates ambiguity of builder pattern in relation to FilterViewType. 

### FilterViewType Class Field Refractor
Also aforementioned, the title field of FilterViewType was refractored to a Criteria type rather than String. 

### RoutesSearchCriteriaTest Refractor
I updated the previous test functions with the new wrapper functions as previously described. Also, I wanted to check my IllegalStateExceptions, such that an error would through if an incorrect Criteria type was given as a function parameter in one of the wrapper functions. 