### PR TITLE
FilterViewTypeList Dev

### DIFF
--- a/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewTypeList.kt
+++ b/app/src/main/java/com/example/routesuggesterapp/ui/adapter/models/FilterViewTypeList.kt
@@ -1,5 +1,22 @@
 package com.example.routesuggesterapp.ui.adapter.models
 
+import com.example.routesuggesterapp.data.network.Criteria
+
 object FilterViewTypeList {
-    val list = arrayListOf<FilterViewType>()
+    val list = arrayListOf(
+        TextFieldViewType(Criteria.MOUNTAIN_NAME, "Long's Peak"),
+        TextFieldViewType(Criteria.ROUTE_NAME, "Keyhole Route"),
+        SwitchViewType(Criteria.IS_STANDARD_ROUTE, true),
+        SwitchViewType(Criteria.IS_SNOW_ROUTE, false),
+        SliderViewType(Criteria.GRADE, 0, 5, listOf(0,1)),
+        TextFieldViewType(Criteria.TRAILHEAD, "Long's Peak Trailhead"),
+        SliderViewType(Criteria.SUMMIT_ELEVATION, 14000, 14438, listOf(14000, 14438)),
+        SliderViewType(Criteria.GAIN, 0, 10000, listOf(0, 1000)),
+        SliderViewType(Criteria.LENGTH, 0, 50, listOf(0, 5)),
+        ChipViewType(Criteria.EXPOSURE),
+        ChipViewType(Criteria.ROCKFALL_POTENTIAL),
+        ChipViewType(Criteria.ROUTE_FINDING),
+        ChipViewType(Criteria.COMMITMENT),
+        SliderViewType(Criteria.ROAD_DIFFICULTY, 0, 6, listOf(0,1))
+    )
 }


### PR DESCRIPTION
I went back and forth if this should be a class that would be injected with hilt. However, I feel as if the object classification creates a singleton instance, and thus--for now--I am comfortable with this set up.

I statically added all the elements of the FitlerViewTypeList, which is injected on FilterFragment's onCreateView() method. As I'm writing this PR, that doesn't make much sense, perhaps I set it up in this way  for mock abilities in integration testing? I don't see myself using a different list of a different size, so then what is the point of creating a specific object type and not using that object type in the FilterFragmentAdapter dataSet field. I might have changed this in a later PR, but if I didn't, I will refractor this. 